### PR TITLE
Fix default avatar ID calculation.

### DIFF
--- a/pages/reference.mdx
+++ b/pages/reference.mdx
@@ -346,7 +346,7 @@ In the case of endpoints that support animated images, the hash will begin with 
 | Video Filter                     | /users/[user_id](/resources/user#user-object)/video-filter-assets/video_filter_id/video_filter_asset.png                                                                                                                    | PNG, JPEG, GIF, MP4, WEBP |
 | Profile Badge                    | /badge-icons/[badge_icon](/resources/user#profile-badge-structure).png                                                                                                                                                      | PNG                       |
 
-^1^ In the case of the Default User Avatar endpoint, the value for `user_index` in the path for migrated users should be the user's ID shifted 22 bits to the left modulo 5 (i.e. `user_id >> 22 % 5`). The value for non-migrated users the user's discriminator modulo 5 (Test#1337 would be `1337 % 5`, which evaluates to 2). See the [section on Discord's new username system](/resources/user#unique-usernames) for more information.
+^1^ In the case of the Default User Avatar endpoint, the value for `user_index` in the path for migrated users should be the user's ID shifted 22 bits to the left modulo 6 (i.e. `user_id >> 22 % 6`). The value for non-migrated users the user's discriminator modulo 5 (Test#1337 would be `1337 % 5`, which evaluates to 2). See the [section on Discord's new username system](/resources/user#unique-usernames) for more information.
 
 ^2^ In the case of the Attachment, Default User Avatar and Sticker endpoints, the size of images returned is constant with the `size` query string parameter being ignored.
 

--- a/pages/resources/user.mdx
+++ b/pages/resources/user.mdx
@@ -55,7 +55,7 @@ For bots, the display name will be the same as their application's name.
 
 #### Default Avatars
 
-For users with migrated accounts, default avatar URLs will be based on the user ID instead of the discriminator. The URL can be calculated using `(user_id >> 22) % 5`.
+For users with migrated accounts, default avatar URLs will be based on the user ID instead of the discriminator. The URL can be calculated using `(user_id >> 22) % 6`. For non-migrated accounts, the URL can be calculated using `discriminator % 5`.
 
 ### User Object
 


### PR DESCRIPTION
The default avatar calculation for migrated users should be `(user_id >> 22) % 6` and should use modulo 6, not modulo 5 because of a new, pink profile picture only available after migration. The discriminator method stays unchanged.