### PR TITLE
feat: implement algolia search

### DIFF
--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -2,6 +2,7 @@ import classNames from "classnames";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import React, { Fragment, useEffect, useState } from "react";
+import Searchbar from "./Searchbar";
 import ThemeSwitcher from "./ThemeSwitcher";
 import Caret from "./icons/Caret";
 import CaretFill from "./icons/CaretFill";
@@ -122,7 +123,11 @@ export default function Navigation() {
         <ThemeSwitcher />
       </div>
 
-      <NavigationSection title="Documentation">
+      <NavigationSection>
+        <div id="searchContainer" className="w-full flex-1 flex">
+          <Searchbar />
+        </div>
+
         <NavigationLink href="/intro">Intro</NavigationLink>
         <NavigationLink
           href="/reference"

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -116,7 +116,7 @@ function NavigationSubLink({ href, children }: NavigationSubLinkProps) {
 export default function Navigation() {
   return (
     <nav className="flex-1 self-stretch mt-5 px-6">
-      <div className="hidden items-center -mt-4 mb-10 md:flex">
+      <div className="hidden items-center -mt-4 mb-8 md:flex">
         <a href="/intro" className="hidden md:block">
           <Userdoccers className="w-9/12 text-black dark:text-white" />
         </a>

--- a/components/Searchbar.tsx
+++ b/components/Searchbar.tsx
@@ -1,0 +1,18 @@
+import { DocSearch } from "@docsearch/react";
+
+const config = {
+  appId: process.env.NEXT_PUBLIC_ALGOLIA_APP_ID ?? "JAJUDFJBI4",
+  apiKey: process.env.NEXT_PUBLIC_ALGOLIA_API_KEY ?? "13092021a31a84e0e8676c10affb9a16",
+  index: process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME ?? "discord-usercers",
+};
+
+export default function Searchbar() {
+  return (
+    <DocSearch
+      appId={config.appId}
+      apiKey={config.apiKey}
+      indexName={config.index}
+      placeholder="Search documentation"
+    />
+  );
+}

--- a/components/ThemeSwitcher.tsx
+++ b/components/ThemeSwitcher.tsx
@@ -37,7 +37,7 @@ export default function ThemeSwitcher() {
         leaveFrom="opacity-100 scale-100"
         leaveTo="opacity-0 scale-95"
       >
-        <Menu.Items className="absolute right-0 mt-2 w-56 dark:bg-table-row-background-secondary-dark bg-white rounded-md focus:outline-none shadow-lg divide-gray-100 dark:divide-gray-900 divide-y origin-top-right ring-1 ring-brand-blurple ring-opacity-5">
+        <Menu.Items className="absolute right-0 mt-2 w-56 dark:bg-table-row-background-secondary-dark bg-white rounded-md focus:outline-none shadow-lg divide-gray-100 dark:divide-gray-900 divide-y origin-top-right ring-1 ring-brand-blurple ring-opacity-5 z-40">
           <div className="px-1 py-1">
             <Menu.Item>
               {({ active }) => (

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:links": "node dist/ci/checkLinks.js"
   },
   "dependencies": {
+    "@docsearch/react": "3",
     "@headlessui/react": "^1.4.1",
     "@mdx-js/loader": "^1.6.22",
     "@mdx-js/react": "^1.6.22",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,6 +8,8 @@ import MDX from "../components/MDX";
 import Menu from "../components/Menu";
 import OpenGraph from "../components/OpenGraph";
 import MenuContext from "../contexts/MenuContext";
+
+import "@docsearch/css";
 import "../stylesheets/tailwind.css";
 import "../stylesheets/styles.css";
 import "../stylesheets/scrollbar.css";
@@ -36,7 +38,7 @@ export default function App({ Component, pageProps }: AppProps) {
   });
 
   return (
-    <ThemeProvider defaultTheme="system" attribute="class">
+    <ThemeProvider defaultTheme="system" attribute="data-theme">
       <MenuContext.Provider value={{ open: sidebarOpen, setOpen, setClose }}>
         {/* eslint-disable-next-line react/jsx-pascal-case */}
         <MDX>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,24 @@
+/* eslint-disable @next/next/no-css-tags, @next/next/no-sync-scripts */
+import { Head, Html, Main, NextScript } from "next/document";
+
+export default function Document() {
+  return (
+    <Html lang="en">
+      <Head>
+        {process.env.NODE_ENV === "development" && process.env.NEXT_PUBLIC_REACT_DEVTOOLS_ADDRESS ? (
+          <script src={process.env.NEXT_PUBLIC_REACT_DEVTOOLS_ADDRESS} />
+        ) : null}
+
+        <link
+          rel="preconnect"
+          href={`https://${process.env.NEXT_PUBLIC_ALGOLIA_APP_ID ?? "JAJUDFJBI4"}-dsn.algolia.net`}
+          crossOrigin="anonymous"
+        />
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@docsearch/react':
+    specifier: '3'
+    version: 3.5.2(@algolia/client-search@4.19.1)(@types/react@18.2.20)(react-dom@18.2.0)(react@18.2.0)(search-insights@2.7.0)
   '@headlessui/react':
     specifier: ^1.4.1
     version: 1.7.10(react-dom@18.2.0)(react@18.2.0)
@@ -135,6 +138,140 @@ packages:
     dependencies:
       tunnel: 0.0.6
     dev: true
+
+  /@algolia/autocomplete-core@1.9.3(@algolia/client-search@4.19.1)(algoliasearch@4.19.1)(search-insights@2.7.0):
+    resolution: {integrity: sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==}
+    dependencies:
+      '@algolia/autocomplete-plugin-algolia-insights': 1.9.3(@algolia/client-search@4.19.1)(algoliasearch@4.19.1)(search-insights@2.7.0)
+      '@algolia/autocomplete-shared': 1.9.3(@algolia/client-search@4.19.1)(algoliasearch@4.19.1)
+    transitivePeerDependencies:
+      - '@algolia/client-search'
+      - algoliasearch
+      - search-insights
+    dev: false
+
+  /@algolia/autocomplete-plugin-algolia-insights@1.9.3(@algolia/client-search@4.19.1)(algoliasearch@4.19.1)(search-insights@2.7.0):
+    resolution: {integrity: sha512-a/yTUkcO/Vyy+JffmAnTWbr4/90cLzw+CC3bRbhnULr/EM0fGNvM13oQQ14f2moLMcVDyAx/leczLlAOovhSZg==}
+    peerDependencies:
+      search-insights: '>= 1 < 3'
+    dependencies:
+      '@algolia/autocomplete-shared': 1.9.3(@algolia/client-search@4.19.1)(algoliasearch@4.19.1)
+      search-insights: 2.7.0
+    transitivePeerDependencies:
+      - '@algolia/client-search'
+      - algoliasearch
+    dev: false
+
+  /@algolia/autocomplete-preset-algolia@1.9.3(@algolia/client-search@4.19.1)(algoliasearch@4.19.1):
+    resolution: {integrity: sha512-d4qlt6YmrLMYy95n5TB52wtNDr6EgAIPH81dvvvW8UmuWRgxEtY0NJiPwl/h95JtG2vmRM804M0DSwMCNZlzRA==}
+    peerDependencies:
+      '@algolia/client-search': '>= 4.9.1 < 6'
+      algoliasearch: '>= 4.9.1 < 6'
+    dependencies:
+      '@algolia/autocomplete-shared': 1.9.3(@algolia/client-search@4.19.1)(algoliasearch@4.19.1)
+      '@algolia/client-search': 4.19.1
+      algoliasearch: 4.19.1
+    dev: false
+
+  /@algolia/autocomplete-shared@1.9.3(@algolia/client-search@4.19.1)(algoliasearch@4.19.1):
+    resolution: {integrity: sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==}
+    peerDependencies:
+      '@algolia/client-search': '>= 4.9.1 < 6'
+      algoliasearch: '>= 4.9.1 < 6'
+    dependencies:
+      '@algolia/client-search': 4.19.1
+      algoliasearch: 4.19.1
+    dev: false
+
+  /@algolia/cache-browser-local-storage@4.19.1:
+    resolution: {integrity: sha512-FYAZWcGsFTTaSAwj9Std8UML3Bu8dyWDncM7Ls8g+58UOe4XYdlgzXWbrIgjaguP63pCCbMoExKr61B+ztK3tw==}
+    dependencies:
+      '@algolia/cache-common': 4.19.1
+    dev: false
+
+  /@algolia/cache-common@4.19.1:
+    resolution: {integrity: sha512-XGghi3l0qA38HiqdoUY+wvGyBsGvKZ6U3vTiMBT4hArhP3fOGLXpIINgMiiGjTe4FVlTa5a/7Zf2bwlIHfRqqg==}
+    dev: false
+
+  /@algolia/cache-in-memory@4.19.1:
+    resolution: {integrity: sha512-+PDWL+XALGvIginigzu8oU6eWw+o76Z8zHbBovWYcrtWOEtinbl7a7UTt3x3lthv+wNuFr/YD1Gf+B+A9V8n5w==}
+    dependencies:
+      '@algolia/cache-common': 4.19.1
+    dev: false
+
+  /@algolia/client-account@4.19.1:
+    resolution: {integrity: sha512-Oy0ritA2k7AMxQ2JwNpfaEcgXEDgeyKu0V7E7xt/ZJRdXfEpZcwp9TOg4TJHC7Ia62gIeT2Y/ynzsxccPw92GA==}
+    dependencies:
+      '@algolia/client-common': 4.19.1
+      '@algolia/client-search': 4.19.1
+      '@algolia/transporter': 4.19.1
+    dev: false
+
+  /@algolia/client-analytics@4.19.1:
+    resolution: {integrity: sha512-5QCq2zmgdZLIQhHqwl55ZvKVpLM3DNWjFI4T+bHr3rGu23ew2bLO4YtyxaZeChmDb85jUdPDouDlCumGfk6wOg==}
+    dependencies:
+      '@algolia/client-common': 4.19.1
+      '@algolia/client-search': 4.19.1
+      '@algolia/requester-common': 4.19.1
+      '@algolia/transporter': 4.19.1
+    dev: false
+
+  /@algolia/client-common@4.19.1:
+    resolution: {integrity: sha512-3kAIVqTcPrjfS389KQvKzliC559x+BDRxtWamVJt8IVp7LGnjq+aVAXg4Xogkur1MUrScTZ59/AaUd5EdpyXgA==}
+    dependencies:
+      '@algolia/requester-common': 4.19.1
+      '@algolia/transporter': 4.19.1
+    dev: false
+
+  /@algolia/client-personalization@4.19.1:
+    resolution: {integrity: sha512-8CWz4/H5FA+krm9HMw2HUQenizC/DxUtsI5oYC0Jxxyce1vsr8cb1aEiSJArQT6IzMynrERif1RVWLac1m36xw==}
+    dependencies:
+      '@algolia/client-common': 4.19.1
+      '@algolia/requester-common': 4.19.1
+      '@algolia/transporter': 4.19.1
+    dev: false
+
+  /@algolia/client-search@4.19.1:
+    resolution: {integrity: sha512-mBecfMFS4N+yK/p0ZbK53vrZbL6OtWMk8YmnOv1i0LXx4pelY8TFhqKoTit3NPVPwoSNN0vdSN9dTu1xr1XOVw==}
+    dependencies:
+      '@algolia/client-common': 4.19.1
+      '@algolia/requester-common': 4.19.1
+      '@algolia/transporter': 4.19.1
+    dev: false
+
+  /@algolia/logger-common@4.19.1:
+    resolution: {integrity: sha512-i6pLPZW/+/YXKis8gpmSiNk1lOmYCmRI6+x6d2Qk1OdfvX051nRVdalRbEcVTpSQX6FQAoyeaui0cUfLYW5Elw==}
+    dev: false
+
+  /@algolia/logger-console@4.19.1:
+    resolution: {integrity: sha512-jj72k9GKb9W0c7TyC3cuZtTr0CngLBLmc8trzZlXdfvQiigpUdvTi1KoWIb2ZMcRBG7Tl8hSb81zEY3zI2RlXg==}
+    dependencies:
+      '@algolia/logger-common': 4.19.1
+    dev: false
+
+  /@algolia/requester-browser-xhr@4.19.1:
+    resolution: {integrity: sha512-09K/+t7lptsweRTueHnSnmPqIxbHMowejAkn9XIcJMLdseS3zl8ObnS5GWea86mu3vy4+8H+ZBKkUN82Zsq/zg==}
+    dependencies:
+      '@algolia/requester-common': 4.19.1
+    dev: false
+
+  /@algolia/requester-common@4.19.1:
+    resolution: {integrity: sha512-BisRkcWVxrDzF1YPhAckmi2CFYK+jdMT60q10d7z3PX+w6fPPukxHRnZwooiTUrzFe50UBmLItGizWHP5bDzVQ==}
+    dev: false
+
+  /@algolia/requester-node-http@4.19.1:
+    resolution: {integrity: sha512-6DK52DHviBHTG2BK/Vv2GIlEw7i+vxm7ypZW0Z7vybGCNDeWzADx+/TmxjkES2h15+FZOqVf/Ja677gePsVItA==}
+    dependencies:
+      '@algolia/requester-common': 4.19.1
+    dev: false
+
+  /@algolia/transporter@4.19.1:
+    resolution: {integrity: sha512-nkpvPWbpuzxo1flEYqNIbGz7xhfhGOKGAZS7tzC+TELgEmi7z99qRyTfNSUlW7LZmB3ACdnqAo+9A9KFBENviQ==}
+    dependencies:
+      '@algolia/cache-common': 4.19.1
+      '@algolia/logger-common': 4.19.1
+      '@algolia/requester-common': 4.19.1
+    dev: false
 
   /@babel/code-frame@7.12.11:
     resolution: {integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==}
@@ -367,6 +504,39 @@ packages:
       '@babel/helper-string-parser': 7.19.4
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
+    dev: false
+
+  /@docsearch/css@3.5.2:
+    resolution: {integrity: sha512-SPiDHaWKQZpwR2siD0KQUwlStvIAnEyK6tAE2h2Wuoq8ue9skzhlyVQ1ddzOxX6khULnAALDiR/isSF3bnuciA==}
+    dev: false
+
+  /@docsearch/react@3.5.2(@algolia/client-search@4.19.1)(@types/react@18.2.20)(react-dom@18.2.0)(react@18.2.0)(search-insights@2.7.0):
+    resolution: {integrity: sha512-9Ahcrs5z2jq/DcAvYtvlqEBHImbm4YJI8M9y0x6Tqg598P40HTEkX7hsMcIuThI+hTFxRGZ9hll0Wygm2yEjng==}
+    peerDependencies:
+      '@types/react': '>= 16.8.0 < 19.0.0'
+      react: '>= 16.8.0 < 19.0.0'
+      react-dom: '>= 16.8.0 < 19.0.0'
+      search-insights: '>= 1 < 3'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      search-insights:
+        optional: true
+    dependencies:
+      '@algolia/autocomplete-core': 1.9.3(@algolia/client-search@4.19.1)(algoliasearch@4.19.1)(search-insights@2.7.0)
+      '@algolia/autocomplete-preset-algolia': 1.9.3(@algolia/client-search@4.19.1)(algoliasearch@4.19.1)
+      '@docsearch/css': 3.5.2
+      '@types/react': 18.2.20
+      algoliasearch: 4.19.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      search-insights: 2.7.0
+    transitivePeerDependencies:
+      - '@algolia/client-search'
     dev: false
 
   /@eslint-community/eslint-utils@4.4.0(eslint@8.47.0):
@@ -806,7 +976,6 @@ packages:
 
   /@types/prop-types@15.7.5:
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
-    dev: true
 
   /@types/react@18.2.20:
     resolution: {integrity: sha512-WKNtmsLWJM/3D5mG4U84cysVY31ivmyw85dE84fOCk5Hx78wezB/XEjVPWl2JTZ5FkEeaTJf+VgUAUn3PE7Isw==}
@@ -814,11 +983,9 @@ packages:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
       csstype: 3.1.1
-    dev: true
 
   /@types/scheduler@0.16.2:
     resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==}
-    dev: true
 
   /@types/semver@7.3.13:
     resolution: {integrity: sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==}
@@ -1156,6 +1323,25 @@ packages:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
     dev: true
+
+  /algoliasearch@4.19.1:
+    resolution: {integrity: sha512-IJF5b93b2MgAzcE/tuzW0yOPnuUyRgGAtaPv5UUywXM8kzqfdwZTO4sPJBzoGz1eOy6H9uEchsJsBFTELZSu+g==}
+    dependencies:
+      '@algolia/cache-browser-local-storage': 4.19.1
+      '@algolia/cache-common': 4.19.1
+      '@algolia/cache-in-memory': 4.19.1
+      '@algolia/client-account': 4.19.1
+      '@algolia/client-analytics': 4.19.1
+      '@algolia/client-common': 4.19.1
+      '@algolia/client-personalization': 4.19.1
+      '@algolia/client-search': 4.19.1
+      '@algolia/logger-common': 4.19.1
+      '@algolia/logger-console': 4.19.1
+      '@algolia/requester-browser-xhr': 4.19.1
+      '@algolia/requester-common': 4.19.1
+      '@algolia/requester-node-http': 4.19.1
+      '@algolia/transporter': 4.19.1
+    dev: false
 
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1508,7 +1694,6 @@ packages:
 
   /csstype@3.1.1:
     resolution: {integrity: sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==}
-    dev: true
 
   /damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
@@ -3647,6 +3832,11 @@ packages:
       ajv: 6.12.6
       ajv-keywords: 3.5.2(ajv@6.12.6)
     dev: true
+
+  /search-insights@2.7.0:
+    resolution: {integrity: sha512-GLbVaGgzYEKMvuJbHRhLi1qoBFnjXZGZ6l4LxOYPCp4lI2jDRB3jPU9/XNhMwv6kvnA9slTreq6pvK+b3o3aqg==}
+    engines: {node: '>=8.16.0'}
+    dev: false
 
   /semver@5.7.1:
     resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}

--- a/stylesheets/prism.css
+++ b/stylesheets/prism.css
@@ -24,7 +24,7 @@ code {
   --prism-highlight: rgba(243, 249, 157, 0.2);
 }
 
-.dark code {
+[data-theme=dark] code {
   --prism-color: #eff0eb;
 
   --prism-background: #282a36;

--- a/stylesheets/scrollbar.css
+++ b/stylesheets/scrollbar.css
@@ -1,9 +1,9 @@
-html.dark {
+html[data-theme=dark] {
     --theme-scrollbar-thumb: #202225;
     --theme-scrollbar-track: #2f3136;
 }
 
-html.light {
+html[data-theme=light] {
     --theme-scrollbar-thumb: #ccc;
     --theme-scrollbar-track: #f2f2f2;
 }

--- a/stylesheets/snowflake-deconstruction.css
+++ b/stylesheets/snowflake-deconstruction.css
@@ -9,11 +9,11 @@
 }
 
 .snowflake-dec-number {
-  font-family: SourceCodePro-Regular, Source Code Pro;
+  font-family: SourceCodePro-Regular, Source Code Pro, monospace;
 }
 
 .snowflake-dec-text {
-  font-family: ArialMT, Arial;
+  font-family: ArialMT, Arial, sans-serif;
 }
 
 .snowflake-dec-reduce-space {
@@ -24,7 +24,7 @@
   fill: #3cb119;
 }
 
-.dark .snowflake-dec-ms {
+[data-theme=dark] .snowflake-dec-ms {
   fill: #7cf559;
 }
 
@@ -32,7 +32,7 @@
   fill: #7d24d6;
 }
 
-.dark .snowflake-dec-worker {
+[data-theme=dark] .snowflake-dec-worker {
   fill: #a65eef;
 }
 
@@ -40,7 +40,7 @@
   fill: #de0ede;
 }
 
-.dark .snowflake-dec-process {
+[data-theme=dark] .snowflake-dec-process {
   fill: #ec40c4;
 }
 
@@ -48,6 +48,6 @@
   fill: #e40606;
 }
 
-.dark .snowflake-dec-increment {
+[data-theme=dark] .snowflake-dec-increment {
   fill: #f75454;
 }

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -37,7 +37,7 @@ em {
   margin: 0 0 1rem;
   color: inherit;
   /*noinspection CssUnresolvedCustomProperty*/
-  background-color: var(--docsearch-searchbox-background);
+  background-color: white;
 }
 
 .DocSearch-Button-Container > svg {
@@ -61,4 +61,10 @@ em {
     /*noinspection CssUnresolvedCustomProperty*/
     color: var(--docsearch-placeholder-color);
   }
+}
+
+/* add table-row-background-secondary-dark to the search bar */
+/* !!! UPDATE THIS IF CHANGING THEME COLOURS !!! */
+[data-theme="dark"] #searchContainer .DocSearch-Button {
+  background-color: #18191c;
 }

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -32,13 +32,33 @@ em {
 
 #searchContainer .DocSearch-Button {
   width: 100%;
-  border-radius: .75rem;
-  padding-left: .7em;
-  margin: 0;
-  margin-bottom: 1rem;
+  border-radius: 0.75rem;
+  padding-left: 0.7em;
+  margin: 0 0 1rem;
+  color: inherit;
+  /*noinspection CssUnresolvedCustomProperty*/
+  background-color: var(--docsearch-searchbox-background);
 }
 
-#searchContainer > button > span.DocSearch-Button-Container > svg {
-    width: 1rem;
-    height: 1rem;
+.DocSearch-Button-Container > svg {
+  width: 1em;
+  height: 1em;
+}
+
+[type="search"] {
+  background-color: initial;
+}
+
+[type="search"]:focus {
+  outline: none;
+  border-color: transparent;
+  box-shadow: none;
+}
+
+@media (max-width: 768px) {
+  #searchContainer .DocSearch-Button-Placeholder {
+    display: initial;
+    /*noinspection CssUnresolvedCustomProperty*/
+    color: var(--docsearch-placeholder-color);
+  }
 }

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -29,3 +29,16 @@ em {
   font-family: "Whitney Medium Italic", var(--text-base);
   font-style: normal;
 }
+
+#searchContainer .DocSearch-Button {
+  width: 100%;
+  border-radius: .75rem;
+  padding-left: .7em;
+  margin: 0;
+  margin-bottom: 1rem;
+}
+
+#searchContainer > button > span.DocSearch-Button-Container > svg {
+    width: 1rem;
+    height: 1rem;
+}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,8 +1,11 @@
 const colors = require("tailwindcss/colors");
 
+/**
+ * @type {import('tailwindcss/tailwind-config').TailwindConfig}
+ */
 module.exports = {
   content: ["./pages/**/*.{js,ts,md,jsx,tsx,mdx}", "./components/**/*.{js,ts,md,jsx,tsx,mdx}"],
-  darkMode: "class",
+  darkMode: ["class", "[data-theme='dark']"],
   theme: {
     extend: {
       padding: {


### PR DESCRIPTION
- adds `@docsearch/react` to dependencies
- updates styling to use `[data-theme]` instead of `.dark` classname (needed for docsearch css to work)
- adds override css for the searchbar to both combat tailwind and tweak to project styling