### PR TITLE
Update create user harvest endpoint

### DIFF
--- a/pages/resources/user.mdx
+++ b/pages/resources/user.mdx
@@ -1504,6 +1504,27 @@ If it exists, returns a [harvest](#harvest-object) object representing the curre
 
 Creates a personal data harvest request for the current user. Returns a [harvest](#harvest-object) object on success.
 
+###### JSON Params
+
+| Field      | Type           | Description                                |
+| ---------- | -------------- | ------------------------------------------ |
+| backends?  | ?array[string] | The types of user data being requested ^1^ |
+
+^1^ Invalid options are ignored and if the array is empty, it requests all data types.
+
+###### Harvest Backend Type
+
+See [the official support page](https://support.discord.com/hc/en-us/articles/360004957991) for more information.
+
+| Value          | Description                                   |
+| -------------- | --------------------------------------------- |
+| Accounts       | All account information                       |
+| Analytics      | Actions the user has taken in Discord         |
+| Activities     | Activity information                          |
+| Messages       | All user messages                             |
+| Programs       | Official Discord programs                     |
+| Servers        | All servers the user is currently a member of |
+
 <RouteHeader method="GET" url="/users/@me/notes">
   Get User Notes
 </RouteHeader>

--- a/pages/resources/user.mdx
+++ b/pages/resources/user.mdx
@@ -1510,20 +1510,20 @@ Creates a personal data harvest request for the current user. Returns a [harvest
 | ---------- | -------------- | ------------------------------------------ |
 | backends?  | ?array[string] | The types of user data being requested ^1^ |
 
-^1^ Invalid options are ignored and if the array is empty, it requests all data types.
+^1^ Invalid options are ignored. If the array is empty after this, it requests all data types.
 
 ###### Harvest Backend Type
 
 See [the official support page](https://support.discord.com/hc/en-us/articles/360004957991) for more information.
 
-| Value          | Description                                   |
-| -------------- | --------------------------------------------- |
-| Accounts       | All account information                       |
-| Analytics      | Actions the user has taken in Discord         |
-| Activities     | Activity information                          |
-| Messages       | All user messages                             |
-| Programs       | Official Discord programs                     |
-| Servers        | All servers the user is currently a member of |
+| Value          | Description                                  |
+| -------------- | -------------------------------------------- |
+| Accounts       | All account information                      |
+| Analytics      | Actions the user has taken in Discord        |
+| Activities     | First-party embedded activity information    |
+| Messages       | All user messages                            |
+| Programs       | Official Discord programs                    |
+| Servers        | All guilds the user is currently a member of |
 
 <RouteHeader method="GET" url="/users/@me/notes">
   Get User Notes


### PR DESCRIPTION
This commit adds the new parameter "backends" to the Create User Harvest endpoint, which allows for selection of specific categories of data to be included in the harvest:
![image](https://github.com/discord-userdoccers/discord-userdoccers/assets/104761702/7dd8d31b-c173-4da3-bae6-6c111a86a3bc)
Currently just a draft PR because I need to test the note more, which involves waiting for discord to actually send the data. There's surprisingly a lot of random discrepancies that I feel like shouldn't be a thing, but I've tried to test as many as possible. I will need to wait for the data first in order to verify though.