### PR TITLE
feat: copy link next to header

### DIFF
--- a/components/icons/Tick.tsx
+++ b/components/icons/Tick.tsx
@@ -4,4 +4,4 @@ export default function TickIcon(props: React.SVGProps<SVGSVGElement>) {
       <path d="M9 16.2 4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4z"></path>
     </svg>
   );
-} 
+}

--- a/components/icons/Tick.tsx
+++ b/components/icons/Tick.tsx
@@ -1,0 +1,7 @@
+export default function TickIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24" {...props}>
+      <path d="M9 16.2 4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4z"></path>
+    </svg>
+  );
+} 

--- a/components/mdx/Heading.tsx
+++ b/components/mdx/Heading.tsx
@@ -17,7 +17,7 @@ function getText(node: React.ReactNode): string {
   }
 
   if (Array.isArray(node)) {
-    return node.map((element) => getText(element as ReactNode)).join("");
+    return node.map(element => getText(element as ReactNode)).join("");
   }
   return "";
 }
@@ -64,7 +64,9 @@ function Heading({ as: As, className, children }: HeadingProps) {
         }}
       >
         {React.createElement(showingCopied ? TickIcon : HyperlinkIcon, {
-          className: `-m-1 ${As === 'h1' ? 'mb-0.25' : 'mb-0.5'} min-w-4 min-h-4 md:group-hover:inline-flex ml-2 w-5 h-5 motion-safe:animate-fade-in-out md:hidden`,
+          className: `-m-1 ${
+            As === "h1" ? "mb-0.25" : "mb-0.5"
+          } min-w-4 min-h-4 md:group-hover:inline-flex ml-2 w-5 h-5 motion-safe:animate-fade-in-out md:hidden`
         })}
       </button>
     </As>
@@ -74,7 +76,7 @@ function Heading({ as: As, className, children }: HeadingProps) {
 export function H1({ className, ...props }: JSX.IntrinsicElements["h1"]) {
   const classes = classNames(
     "not:first-of-type:mt-2 mb-2 mt-3 text-4xl font-bold leading-tight sm:leading-loose",
-    className,
+    className
   );
   return <Heading as="h1" className={classes} {...props} />;
 }

--- a/components/mdx/Heading.tsx
+++ b/components/mdx/Heading.tsx
@@ -17,7 +17,7 @@ function getText(node: React.ReactNode): string {
   }
 
   if (Array.isArray(node)) {
-    return node.map(element => getText(element as ReactNode)).join("");
+    return node.map((element) => getText(element as ReactNode)).join("");
   }
   return "";
 }
@@ -66,7 +66,7 @@ function Heading({ as: As, className, children }: HeadingProps) {
         {React.createElement(showingCopied ? TickIcon : HyperlinkIcon, {
           className: `-m-1 ${
             As === "h1" ? "mb-0.25" : "mb-0.5"
-          } min-w-4 min-h-4 md:group-hover:inline-flex ml-2 w-5 h-5 motion-safe:animate-fade-in-out md:hidden`
+          } min-w-4 min-h-4 md:group-hover:inline-flex ml-2 w-5 h-5 motion-safe:animate-fade-in-out md:hidden`,
         })}
       </button>
     </As>
@@ -76,7 +76,7 @@ function Heading({ as: As, className, children }: HeadingProps) {
 export function H1({ className, ...props }: JSX.IntrinsicElements["h1"]) {
   const classes = classNames(
     "not:first-of-type:mt-2 mb-2 mt-3 text-4xl font-bold leading-tight sm:leading-loose",
-    className
+    className,
   );
   return <Heading as="h1" className={classes} {...props} />;
 }

--- a/components/mdx/Heading.tsx
+++ b/components/mdx/Heading.tsx
@@ -1,6 +1,7 @@
 import classNames from "classnames";
 import React, { isValidElement, ReactNode } from "react";
 import HyperlinkIcon from "../icons/Hyperlink";
+import TickIcon from "../icons/Tick";
 
 function getText(node: React.ReactNode): string {
   if (typeof node === "string") {
@@ -30,14 +31,43 @@ export interface HeadingProps {
 function Heading({ as: As, className, children }: HeadingProps) {
   const anchor = getText(children);
   const classes = classNames("flex items-center text-black dark:text-white", className);
+  const [showingCopied, setShowingCopied] = React.useState(false);
+
+  // return to normal icon after 1 second
+  React.useEffect(() => {
+    if (showingCopied) {
+      const timeout = setTimeout(() => {
+        setShowingCopied(false);
+      }, 1000);
+
+      return () => {
+        clearTimeout(timeout);
+      };
+    }
+  }, [showingCopied]);
 
   return (
-    <a className="group" href={`#${anchor}`}>
-      <As id={anchor} className={classes}>
-        {children}
-        <HyperlinkIcon className="min-w-4 min-h-4 md:group-hover:inline-flex ml-2 w-4 h-4 motion-safe:animate-fade-in-out md:hidden" />
-      </As>
-    </a>
+    <As className={"group " + classes} id={anchor}>
+      <a href={`#${anchor}`}>{children}</a>
+      <button
+        type="button"
+        // href={`#${anchor}`}
+        onClick={() => {
+          navigator.clipboard
+            .writeText(`${window.location.href.split("#")[0]}#${anchor}`)
+            .then(() => {
+              setShowingCopied(true);
+            })
+            .catch(() => {
+              // noop to avoid unhandled promise rejection
+            });
+        }}
+      >
+        {React.createElement(showingCopied ? TickIcon : HyperlinkIcon, {
+          className: `-m-1 ${As === 'h1' ? 'mb-0.25' : 'mb-0.5'} min-w-4 min-h-4 md:group-hover:inline-flex ml-2 w-5 h-5 motion-safe:animate-fade-in-out md:hidden`,
+        })}
+      </button>
+    </As>
   );
 }
 


### PR DESCRIPTION
This changes the headers' behaviour slightly:

1. Clicking on the header text navigates to the anchor, as per before
2. I've changed the link button next to the text to a) copy the link and b) change to a tick icon to confirm this if successful	