### PR TITLE
Document OAuth2 token endpoints and `OAUTH2_TOKEN_REVOKE`/`USER_CONNECTIONS_UPDATE` events

### DIFF
--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -722,6 +722,7 @@ export default function Navigation() {
               <NavigationSubLink href="/topics/oauth2#bots">Bots</NavigationSubLink>
               <NavigationSubLink href="/topics/oauth2#webhooks">Webhooks</NavigationSubLink>
               <NavigationSubLink href="/topics/oauth2#endpoints">Endpoints</NavigationSubLink>
+              <NavigationSubLink href="/topics/oauth2#oauth2-token-object">OAuth2 Token Object</NavigationSubLink>
             </Fragment>
           }
         >

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -721,8 +721,8 @@ export default function Navigation() {
               </NavigationSubLink>
               <NavigationSubLink href="/topics/oauth2#bots">Bots</NavigationSubLink>
               <NavigationSubLink href="/topics/oauth2#webhooks">Webhooks</NavigationSubLink>
-              <NavigationSubLink href="/topics/oauth2#endpoints">Endpoints</NavigationSubLink>
               <NavigationSubLink href="/topics/oauth2#oauth2-token-object">OAuth2 Token Object</NavigationSubLink>
+              <NavigationSubLink href="/topics/oauth2#endpoints">Endpoints</NavigationSubLink>
             </Fragment>
           }
         >

--- a/components/mdx/Heading.tsx
+++ b/components/mdx/Heading.tsx
@@ -47,7 +47,7 @@ function Heading({ as: As, className, children }: HeadingProps) {
   }, [showingCopied]);
 
   return (
-    <As className={"group " + classes} id={anchor}>
+    <As className={`group ${classes}`} id={anchor}>
       <a href={`#${anchor}`}>{children}</a>
       <button
         type="button"

--- a/pages/resources/user.mdx
+++ b/pages/resources/user.mdx
@@ -204,45 +204,45 @@ For users with migrated accounts, default avatar URLs will be based on the user 
 
 ###### User Flags
 
-| Value       | Name                         | Description                                                                                 | Public     |
-| ----------- | ---------------------------- | ------------------------------------------------------------------------------------------- | ---------- |
-| 1 << 0      | STAFF                        | Discord Staff                                                                               | Yes        |
-| 1 << 1      | PARTNER                      | Partnered Server Owner                                                                      | Yes        |
-| 1 << 2      | HYPESQUAD                    | HypeSquad Events                                                                            | Yes        |
-| 1 << 3      | BUG_HUNTER_LEVEL_1           | Level 1 Discord Bug Hunter                                                                  | Yes        |
-| 1 << 4      | MFA_SMS                      | SMS enabled as a multi-factor authentication backup                                         | No         |
-| 1 << 5      | PREMIUM_PROMO_DISMISSED      | User has dismissed the current premium (Nitro) promotion                                    | No         |
-| 1 << 6      | HYPESQUAD_ONLINE_HOUSE_1     | HypeSquad Bravery                                                                           | Yes        |
-| 1 << 7      | HYPESQUAD_ONLINE_HOUSE_2     | HypeSquad Brilliance                                                                        | Yes        |
-| 1 << 8      | HYPESQUAD_ONLINE_HOUSE_3     | HypeSquad Balance                                                                           | Yes        |
-| 1 << 9      | PREMIUM_EARLY_SUPPORTER      | Early Premium (Nitro) Supporter                                                             | Yes        |
-| 1 << 10     | TEAM_PSEUDO_USER             | User is a [Team](/resources/team)                                                           | Yes        |
-| 1 << 11     | INTERNAL_APPLICATION         | User has a pending partner or verification application                                      | No ^1^     |
-| ~~1 << 12~~ | ~~SYSTEM~~                   | ~~User is a system user (i.e. official Discord account)~~                                   | ~~Yes~~    |
-| 1 << 13     | HAS_UNREAD_URGENT_MESSAGES   | User has unread urgent system messages; an urgent message is one sent from Trust and Safety | No         |
-| 1 << 14     | BUG_HUNTER_LEVEL_2           | Level 2 Discord Bug Hunter                                                                  | Yes        |
-| 1 << 15     | UNDERAGE_DELETED             | User is scheduled for deletion for being under the minimum required age                     | No ^1^     |
-| 1 << 16     | VERIFIED_BOT                 | Verified Bot                                                                                | Yes        |
-| 1 << 17     | VERIFIED_DEVELOPER           | Early Verified Bot Developer                                                                | Yes        |
-| 1 << 18     | CERTIFIED_MODERATOR          | Moderator Programs Alumni                                                                   | Yes        |
-| 1 << 19     | BOT_HTTP_INTERACTIONS        | Bot uses only HTTP interactions and is shown in the online member list                      | Yes        |
-| 1 << 20     | SPAMMER                      | User is marked as a spammer and has their messages collapsed in the UI                      | Yes        |
-| 1 << 21     | DISABLE_PREMIUM              | User has manually disabled premium (Nitro) features                                         | No         |
-| 1 << 22     | ACTIVE_DEVELOPER             | [Active Developer](https://support-dev.discord.com/hc/articles/10113997751447)              | Yes        |
-| 1 << 23     | PROVISIONAL_ACCOUNT          | User is a provisional account used with the social layer integration                        | Yes        |
-| 1 << 33     | HIGH_GLOBAL_RATE_LIMIT       | User has a raised global ratelimit                                                          | No ^1^     |
-| 1 << 34     | DELETED                      | User's account is deleted                                                                   | No ^1^     |
-| 1 << 35     | DISABLED_SUSPICIOUS_ACTIVITY | User's account is disabled for suspicious activity                                          | No ^1^     |
-| 1 << 36     | SELF_DELETED                 | User deleted their own account                                                              | No ^1^     |
-| 1 << 37     | PREMIUM_DISCRIMINATOR        | User has a premium (Nitro) custom discriminator                                             | No ^1^     |
-| 1 << 38     | USED_DESKTOP_CLIENT          | User has used the desktop client                                                            | No ^1^     |
-| 1 << 39     | USED_WEB_CLIENT              | User has used the web client                                                                | No ^1^     |
-| 1 << 40     | USED_MOBILE_CLIENT           | User has used the mobile client                                                             | No ^1^     |
-| 1 << 41     | DISABLED                     | User's account is disabled                                                                  | No ^1^     |
-| 1 << 43     | VERIFIED_EMAIL               | User has a verified email                                                                   | No ^1^     |
-| 1 << 44     | QUARANTINED                  | User is quarantined and cannot create DMs or accept invites                                 | No         |
-| 1 << 50     | COLLABORATOR                 | User is a collaborator and is considered staff                                              | No         |
-| 1 << 51     | RESTRICTED_COLLABORATOR      | User is a restricted collaborator and is considered staff                                   | No         |
+| Value       | Name                         | Description                                                                                 | Public  |
+| ----------- | ---------------------------- | ------------------------------------------------------------------------------------------- | ------- |
+| 1 << 0      | STAFF                        | Discord Staff                                                                               | Yes     |
+| 1 << 1      | PARTNER                      | Partnered Server Owner                                                                      | Yes     |
+| 1 << 2      | HYPESQUAD                    | HypeSquad Events                                                                            | Yes     |
+| 1 << 3      | BUG_HUNTER_LEVEL_1           | Level 1 Discord Bug Hunter                                                                  | Yes     |
+| 1 << 4      | MFA_SMS                      | SMS enabled as a multi-factor authentication backup                                         | No      |
+| 1 << 5      | PREMIUM_PROMO_DISMISSED      | User has dismissed the current premium (Nitro) promotion                                    | No      |
+| 1 << 6      | HYPESQUAD_ONLINE_HOUSE_1     | HypeSquad Bravery                                                                           | Yes     |
+| 1 << 7      | HYPESQUAD_ONLINE_HOUSE_2     | HypeSquad Brilliance                                                                        | Yes     |
+| 1 << 8      | HYPESQUAD_ONLINE_HOUSE_3     | HypeSquad Balance                                                                           | Yes     |
+| 1 << 9      | PREMIUM_EARLY_SUPPORTER      | Early Premium (Nitro) Supporter                                                             | Yes     |
+| 1 << 10     | TEAM_PSEUDO_USER             | User is a [Team](/resources/team)                                                           | Yes     |
+| 1 << 11     | INTERNAL_APPLICATION         | User has a pending partner or verification application                                      | No ^1^  |
+| ~~1 << 12~~ | ~~SYSTEM~~                   | ~~User is a system user (i.e. official Discord account)~~                                   | ~~Yes~~ |
+| 1 << 13     | HAS_UNREAD_URGENT_MESSAGES   | User has unread urgent system messages; an urgent message is one sent from Trust and Safety | No      |
+| 1 << 14     | BUG_HUNTER_LEVEL_2           | Level 2 Discord Bug Hunter                                                                  | Yes     |
+| 1 << 15     | UNDERAGE_DELETED             | User is scheduled for deletion for being under the minimum required age                     | No ^1^  |
+| 1 << 16     | VERIFIED_BOT                 | Verified Bot                                                                                | Yes     |
+| 1 << 17     | VERIFIED_DEVELOPER           | Early Verified Bot Developer                                                                | Yes     |
+| 1 << 18     | CERTIFIED_MODERATOR          | Moderator Programs Alumni                                                                   | Yes     |
+| 1 << 19     | BOT_HTTP_INTERACTIONS        | Bot uses only HTTP interactions and is shown in the online member list                      | Yes     |
+| 1 << 20     | SPAMMER                      | User is marked as a spammer and has their messages collapsed in the UI                      | Yes     |
+| 1 << 21     | DISABLE_PREMIUM              | User has manually disabled premium (Nitro) features                                         | No      |
+| 1 << 22     | ACTIVE_DEVELOPER             | [Active Developer](https://support-dev.discord.com/hc/articles/10113997751447)              | Yes     |
+| 1 << 23     | PROVISIONAL_ACCOUNT          | User is a provisional account used with the social layer integration                        | Yes     |
+| 1 << 33     | HIGH_GLOBAL_RATE_LIMIT       | User has a raised global ratelimit                                                          | No ^1^  |
+| 1 << 34     | DELETED                      | User's account is deleted                                                                   | No ^1^  |
+| 1 << 35     | DISABLED_SUSPICIOUS_ACTIVITY | User's account is disabled for suspicious activity                                          | No ^1^  |
+| 1 << 36     | SELF_DELETED                 | User deleted their own account                                                              | No ^1^  |
+| 1 << 37     | PREMIUM_DISCRIMINATOR        | User has a premium (Nitro) custom discriminator                                             | No ^1^  |
+| 1 << 38     | USED_DESKTOP_CLIENT          | User has used the desktop client                                                            | No ^1^  |
+| 1 << 39     | USED_WEB_CLIENT              | User has used the web client                                                                | No ^1^  |
+| 1 << 40     | USED_MOBILE_CLIENT           | User has used the mobile client                                                             | No ^1^  |
+| 1 << 41     | DISABLED                     | User's account is disabled                                                                  | No ^1^  |
+| 1 << 43     | VERIFIED_EMAIL               | User has a verified email                                                                   | No ^1^  |
+| 1 << 44     | QUARANTINED                  | User is quarantined and cannot create DMs or accept invites                                 | No      |
+| 1 << 50     | COLLABORATOR                 | User is a collaborator and is considered staff                                              | No      |
+| 1 << 51     | RESTRICTED_COLLABORATOR      | User is a restricted collaborator and is considered staff                                   | No      |
 
 ^1^ Not exposed to the API, can only be found in [user data harvests](#harvest-object).
 

--- a/pages/topics/gateway-events.mdx
+++ b/pages/topics/gateway-events.mdx
@@ -636,7 +636,7 @@ These events directly correspond with a specific action or state change that has
 | [Stage Instance Delete](#stage-instance-delete)                                   | Stage instance was deleted or closed                                                            |
 | [Typing Start](#typing-start)                                                     | User started typing in a channel                                                                |
 | [User Update](#user-update)                                                       | Current user changed                                                                            |
-| [User Application Remove](#user-application-remove)                               | User uninstalled an application                                                                    |
+| [User Application Remove](#user-application-remove)                               | User uninstalled an application                                                                 |
 | [User Connections Update](#user-connections-update)                               | User connection was created, updated, or deleted                                                |
 | [User Note Update](#user-note-update)                                             | User note was updated                                                                           |
 | [User Required Action Update](#user-required-action-update)                       | User's required action was updated                                                              |

--- a/pages/topics/gateway-events.mdx
+++ b/pages/topics/gateway-events.mdx
@@ -624,6 +624,7 @@ These events directly correspond with a specific action or state change that has
 | [Message Reaction Remove](#message-reaction-remove)                               | User removed a reaction from a message                                                          |
 | [Message Reaction Remove All](#message-reaction-remove-all)                       | All reactions were explicitly removed from a message                                            |
 | [Message Reaction Remove Emoji](#message-reaction-remove-emoji)                   | All reactions for a given emoji were explicitly removed from a message                          |
+| [OAuth2 Token Revoke](#oauth2-token-revoke)                                       | OAuth2 application was deauthorized                                                             |
 | [Recent Mention Delete](#recent-mention-delete)                                   | Recent message that mentioned the current user was acknowledged                                 |
 | [Last Messages](#last-messages)                                                   | Response to [Request Last Messages](#request-last-messages)                                     |
 | [Presence Update](#presence-update)                                               | User presence was updated                                                                       |
@@ -634,6 +635,8 @@ These events directly correspond with a specific action or state change that has
 | [Stage Instance Update](#stage-instance-update)                                   | Stage instance was updated                                                                      |
 | [Stage Instance Delete](#stage-instance-delete)                                   | Stage instance was deleted or closed                                                            |
 | [Typing Start](#typing-start)                                                     | User started typing in a channel                                                                |
+| [User Application Remove](#user-application-remove)                               | User uninstalled application                                                                    |
+| [User Connections Update](#user-connections-update)                               | User connection was created, updated, or deleted                                                |
 | [User Update](#user-update)                                                       | Current user changed                                                                            |
 | [User Note Update](#user-note-update)                                             | User note was updated                                                                           |
 | [User Required Action Update](#user-required-action-update)                       | User's required action was updated                                                              |
@@ -1743,6 +1746,17 @@ Sent when a user removes all instances of a given emoji from the reactions of a 
 | guild_id?  | snowflake                                             | The ID of the guild        |
 | emoji      | partial [emoji object](/resources/emoji#emoji-object) | The emoji that was removed |
 
+#### OAuth2 Token Revoke
+
+Sent when a OAuth2 application is deauthorized.
+
+###### OAuth2 Token Revoke Structure
+
+| Field          | Type      | Description                       |
+| -------------- | --------- | --------------------------------- |
+| access_token   | string    | The access token that was revoked |
+| application_id | snowflake | The ID of associated application  |
+
 #### Recent Mention Delete
 
 Sent when a message that mentioned the current user in the last week is acknowledged and deleted.
@@ -1863,6 +1877,26 @@ Sent when a user starts typing in a channel.
 | member?    | [member](/resources/guild#guild-member-object) object | the member who started typing if this happened in a guild |
 
 ### Current User
+
+#### User Application Remove
+
+Sent when current user uninstalls application.
+
+###### User Application Remove Structure
+
+| Field          | Type      | Description               |
+| -------------- | --------- | ------------------------- |
+| application_id | snowflake | The ID of the application |
+
+#### User Connections Update
+
+Sent when current user has their connections updated. Inner payload is either [connection](/resources/user#connection-object) object, or following object.
+
+##### User Connections Update Structure
+
+| Field   | Type      | Description                |
+| ------- | --------- | -------------------------- |
+| user_id | snowflake | The ID of the current user |
 
 #### User Update
 

--- a/pages/topics/gateway-events.mdx
+++ b/pages/topics/gateway-events.mdx
@@ -636,7 +636,7 @@ These events directly correspond with a specific action or state change that has
 | [Stage Instance Delete](#stage-instance-delete)                                   | Stage instance was deleted or closed                                                            |
 | [Typing Start](#typing-start)                                                     | User started typing in a channel                                                                |
 | [User Update](#user-update)                                                       | Current user changed                                                                            |
-| [User Application Remove](#user-application-remove)                               | User uninstalled application                                                                    |
+| [User Application Remove](#user-application-remove)                               | User uninstalled an application                                                                    |
 | [User Connections Update](#user-connections-update)                               | User connection was created, updated, or deleted                                                |
 | [User Note Update](#user-note-update)                                             | User note was updated                                                                           |
 | [User Required Action Update](#user-required-action-update)                       | User's required action was updated                                                              |

--- a/pages/topics/gateway-events.mdx
+++ b/pages/topics/gateway-events.mdx
@@ -624,9 +624,9 @@ These events directly correspond with a specific action or state change that has
 | [Message Reaction Remove](#message-reaction-remove)                               | User removed a reaction from a message                                                          |
 | [Message Reaction Remove All](#message-reaction-remove-all)                       | All reactions were explicitly removed from a message                                            |
 | [Message Reaction Remove Emoji](#message-reaction-remove-emoji)                   | All reactions for a given emoji were explicitly removed from a message                          |
-| [OAuth2 Token Revoke](#oauth2-token-revoke)                                       | OAuth2 application was deauthorized                                                             |
 | [Recent Mention Delete](#recent-mention-delete)                                   | Recent message that mentioned the current user was acknowledged                                 |
 | [Last Messages](#last-messages)                                                   | Response to [Request Last Messages](#request-last-messages)                                     |
+| [OAuth2 Token Revoke](#oauth2-token-revoke)                                       | OAuth2 application was deauthorized                                                             |
 | [Presence Update](#presence-update)                                               | User presence was updated                                                                       |
 | [Relationship Add](#relationship-add)                                             | User had a relationship added                                                                   |
 | [Relationship Update](#relationship-update)                                       | User had a relationship updated                                                                 |
@@ -635,9 +635,9 @@ These events directly correspond with a specific action or state change that has
 | [Stage Instance Update](#stage-instance-update)                                   | Stage instance was updated                                                                      |
 | [Stage Instance Delete](#stage-instance-delete)                                   | Stage instance was deleted or closed                                                            |
 | [Typing Start](#typing-start)                                                     | User started typing in a channel                                                                |
+| [User Update](#user-update)                                                       | Current user changed                                                                            |
 | [User Application Remove](#user-application-remove)                               | User uninstalled application                                                                    |
 | [User Connections Update](#user-connections-update)                               | User connection was created, updated, or deleted                                                |
-| [User Update](#user-update)                                                       | Current user changed                                                                            |
 | [User Note Update](#user-note-update)                                             | User note was updated                                                                           |
 | [User Required Action Update](#user-required-action-update)                       | User's required action was updated                                                              |
 | [Voice State Update](#voice-state-update)                                         | User joined, left, or moved a voice channel                                                     |
@@ -1746,17 +1746,6 @@ Sent when a user removes all instances of a given emoji from the reactions of a 
 | guild_id?  | snowflake                                             | The ID of the guild        |
 | emoji      | partial [emoji object](/resources/emoji#emoji-object) | The emoji that was removed |
 
-#### OAuth2 Token Revoke
-
-Sent when a OAuth2 application is deauthorized.
-
-###### OAuth2 Token Revoke Structure
-
-| Field          | Type      | Description                                         |
-| -------------- | --------- | --------------------------------------------------- |
-| access_token   | string    | The access token that was revoked                   |
-| application_id | snowflake | The ID of application that is associated with token |
-
 #### Recent Mention Delete
 
 Sent when a message that mentioned the current user in the last week is acknowledged and deleted.
@@ -1777,6 +1766,19 @@ Sent in response to [Request Last Messages](#request-last-messages).
 | -------- | ---------------------------------------------------------- | --------------------------------------- |
 | guild_id | snowflake                                                  | The ID of the guild                     |
 | messages | array[[message](/resources/message#message-object) object] | Last messages of the requested channels |
+
+### OAuth2
+
+#### OAuth2 Token Revoke
+
+Sent when an OAuth2 application is deauthorized.
+
+###### OAuth2 Token Revoke Structure
+
+| Field          | Type      | Description                                            |
+| -------------- | --------- | ------------------------------------------------------ |
+| access_token   | string    | The access token that was revoked                      |
+| application_id | snowflake | The OAuth2 application who's authorization was revoked |
 
 ### Presence
 
@@ -1878,9 +1880,13 @@ Sent when a user starts typing in a channel.
 
 ### Current User
 
+#### User Update
+
+Sent when properties about the current user change. Inner payload is a [user](/resources/user#user-object) object.
+
 #### User Application Remove
 
-Sent when current user uninstalls application.
+Sent when the current user uninstalls an application.
 
 ###### User Application Remove Structure
 
@@ -1890,17 +1896,13 @@ Sent when current user uninstalls application.
 
 #### User Connections Update
 
-Sent when current user has their connections updated. Inner payload is either [connection](/resources/user#connection-object) object, or following object.
+Sent when the current user has their connections updated. Inner payload is either a [connection](/resources/user#connection-object) object, or the following object:
 
 ##### User Connections Update Structure
 
 | Field   | Type      | Description                |
 | ------- | --------- | -------------------------- |
 | user_id | snowflake | The ID of the current user |
-
-#### User Update
-
-Sent when properties about the current user change. Inner payload is a [user](/resources/user#user-object) object.
 
 #### User Note Update
 

--- a/pages/topics/gateway-events.mdx
+++ b/pages/topics/gateway-events.mdx
@@ -1778,7 +1778,7 @@ Sent when an OAuth2 application is deauthorized.
 | Field          | Type      | Description                                            |
 | -------------- | --------- | ------------------------------------------------------ |
 | access_token   | string    | The access token that was revoked                      |
-| application_id | snowflake | The OAuth2 application who's authorization was revoked |
+| application_id | snowflake | The OAuth2 application whose authorization was revoked |
 
 ### Presence
 

--- a/pages/topics/gateway-events.mdx
+++ b/pages/topics/gateway-events.mdx
@@ -1752,10 +1752,10 @@ Sent when a OAuth2 application is deauthorized.
 
 ###### OAuth2 Token Revoke Structure
 
-| Field          | Type      | Description                       |
-| -------------- | --------- | --------------------------------- |
-| access_token   | string    | The access token that was revoked |
-| application_id | snowflake | The ID of associated application  |
+| Field          | Type      | Description                                         |
+| -------------- | --------- | --------------------------------------------------- |
+| access_token   | string    | The access token that was revoked                   |
+| application_id | snowflake | The ID of application that is associated with token |
 
 #### Recent Mention Delete
 

--- a/pages/topics/oauth2.mdx
+++ b/pages/topics/oauth2.mdx
@@ -377,6 +377,18 @@ From this object, you should store the `webhook.token` and `webhook.id`. See the
 
 Any user that wishes to add your webhook to their channel will need to go through the full OAuth2 flow. A new webhook is created each time, so you will need to save the token and id. If you wish to send a message to all your webhooks, you'll need to iterate over each stored id:token combination and make `POST` requests to each one. Be mindful of our [Rate Limits](/topics/rate-limits#rate-limits)!
 
+### OAuth2 Token Object
+
+Used to represent an OAuth2 authorization.
+
+###### OAuth2 Token Structure
+
+| Field       | Type                                                                    | Description                                            |
+| ----------- | ----------------------------------------------------------------------- | ------------------------------------------------------ |
+| id          | snowflake                                                               | The ID of the token                                    |
+| scopes      | array[string]                                                           | The scopes the user has authorized the application for |
+| application | partial [application](/resources/application#application-object) object | The application associated with token                  |
+
 ## Endpoints
 
 <RouteHeader method="GET" url="/oauth2/@me" supportsOAuth2>
@@ -428,3 +440,15 @@ This endpoint is only usable with an OAuth2 access token.
   }
 }
 ```
+
+<RouteHeader method="GET" url="/oauth2/tokens">
+  List OAuth2 tokens
+</RouteHeader>
+
+Returns a list of [OAuth2 token](#oauth2-token-object) objects.
+
+<RouteHeader method="DELETE" url="/oauth2/tokens/{token.id}">
+  Delete OAuth2 Token
+</RouteHeader>
+
+Revokes the given token ID. Returns a 204 empty response on success. Fires a [OAuth2 Token Revoke](/topics/gateway-events#oauth2-token-revoke) and optionally [User Application Remove](/topics/gateway-events#user-application-remove) Gateway event.

--- a/pages/topics/oauth2.mdx
+++ b/pages/topics/oauth2.mdx
@@ -379,7 +379,7 @@ Any user that wishes to add your webhook to their channel will need to go throug
 
 ### OAuth2 Token Object
 
-Used to represent an OAuth2 authorization.
+Represents an OAuth2 authorization.
 
 ###### OAuth2 Token Structure
 
@@ -387,7 +387,7 @@ Used to represent an OAuth2 authorization.
 | ----------- | ----------------------------------------------------------------------- | ------------------------------------------------------ |
 | id          | snowflake                                                               | The ID of the token                                    |
 | scopes      | array[string]                                                           | The scopes the user has authorized the application for |
-| application | partial [application](/resources/application#application-object) object | The application associated with token                  |
+| application | partial [application](/resources/application#application-object) object | The authorized application                             |
 
 ## Endpoints
 
@@ -451,4 +451,4 @@ Returns a list of [OAuth2 token](#oauth2-token-object) objects.
   Delete OAuth2 Token
 </RouteHeader>
 
-Revokes the given token. Returns a 204 empty response on success. Fires a [OAuth2 Token Revoke](/topics/gateway-events#oauth2-token-revoke) and optionally [User Application Remove](/topics/gateway-events#user-application-remove) Gateway event.
+Revokes the given token. Returns a 204 empty response on success. Fires a [OAuth2 Token Revoke](/topics/gateway-events#oauth2-token-revoke) and optionally a [User Application Remove](/topics/gateway-events#user-application-remove) Gateway event.

--- a/pages/topics/oauth2.mdx
+++ b/pages/topics/oauth2.mdx
@@ -451,4 +451,4 @@ Returns a list of [OAuth2 token](#oauth2-token-object) objects.
   Delete OAuth2 Token
 </RouteHeader>
 
-Revokes the given token ID. Returns a 204 empty response on success. Fires a [OAuth2 Token Revoke](/topics/gateway-events#oauth2-token-revoke) and optionally [User Application Remove](/topics/gateway-events#user-application-remove) Gateway event.
+Revokes the given token. Returns a 204 empty response on success. Fires a [OAuth2 Token Revoke](/topics/gateway-events#oauth2-token-revoke) and optionally [User Application Remove](/topics/gateway-events#user-application-remove) Gateway event.

--- a/pages/topics/oauth2.mdx
+++ b/pages/topics/oauth2.mdx
@@ -442,7 +442,7 @@ This endpoint is only usable with an OAuth2 access token.
 ```
 
 <RouteHeader method="GET" url="/oauth2/tokens">
-  List OAuth2 tokens
+  Get OAuth2 Tokens
 </RouteHeader>
 
 Returns a list of [OAuth2 token](#oauth2-token-object) objects.


### PR DESCRIPTION
`npm run prettier:fix ; npm run lint:fix` formatted UserFlags but I don't see any harm in it