### PR TITLE
Fix max member_ids count

### DIFF
--- a/pages/resources/guild.mdx
+++ b/pages/resources/guild.mdx
@@ -1808,9 +1808,9 @@ Adds multiple [guild members](#guild-member-object) to a [role](/topics/permissi
 
 ###### JSON Params
 
-| Field      | Type             | Description                                    |
-| ---------- | ---------------- | ---------------------------------------------- |
-| member_ids | array[snowflake] | The member IDs to assign the role to (max 100) |
+| Field      | Type             | Description                                   |
+| ---------- | ---------------- | --------------------------------------------- |
+| member_ids | array[snowflake] | The member IDs to assign the role to (max 30) |
 
 ###### Example Response
 


### PR DESCRIPTION
This PR aims to adjust the max member_ids count to the current limit.

```javascript
{
    "message": "Invalid Form Body",
    "code": 50035,
    "errors": {
        "member_ids": {
            "_errors": [
                {
                    "code": "BASE_TYPE_BAD_LENGTH",
                    "message": "Must be between 1 and 30 in length."
                }
            ]
        }
    }
}
``` 