### PR TITLE
Document application command index struct + eps, application integration types

### DIFF
--- a/pages/interactions/application-commands.mdx
+++ b/pages/interactions/application-commands.mdx
@@ -104,7 +104,7 @@ Multiple different resources are queryable with the application command index st
 | Field                      | Type                                                                                                     | Description                                                             |
 | -------------------------- | -------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
 | applications               | array[[partial application](/resources/application#partial-application-structure) object]                | List of partial application(s) relevant to the requested resource       |
-| application-commands ^1^   | array[[application command](/interactions/application-commands#application-command-structure) object]    | List of application commands                                            |
+| application-commands ^1^   | array[[application command](#application-command-structure) object]                                      | List of application commands                                            |
 | version                    | snowflake                                                                                                | Snowflake representing when commands were last updated                  |
 
 ^1^ This field will sometimes be an empty array when requested via [Get Application Command Index](#get-application-command-index) even if the application has registered global commmands. For more reliability, actual global commands should be obtained via [Get Global Application Commands](#get-global-application-commands).
@@ -888,7 +888,7 @@ When someone uses a message command, your application will receive an interactio
 ### Endpoints
 
 <RouteHeader method="GET" url="/applications/{application.id}/application-command-index">
-  Get Application Commands Index
+  Get Application Command Index
 </RouteHeader>
 
 Returns an [Application Command Index](#application-command-index-object) object.

--- a/pages/interactions/application-commands.mdx
+++ b/pages/interactions/application-commands.mdx
@@ -24,6 +24,7 @@ and can include spaces.
 | description         | string                                                                       | 1-100 character description for `CHAT_INPUT` commands, empty string for `USER` and `MESSAGE` commands | all         |
 | options?            | array of [application command option](#application-command-option-structure) | the parameters for the command, max 25                                                                | CHAT_INPUT  |
 | default_permission? | boolean (default `true`)                                                     | whether the command is enabled by default when the app is added to a guild                            | all         |
+| integration_types?  | array[[application integration type](#application-integration-types)]        | Contexts where the command can be used, if global; defaults `0`                                       | all         |
 
 ###### Application Command Types
 
@@ -32,6 +33,13 @@ and can include spaces.
 | CHAT_INPUT | 1    | Slash commands; a text-based command that shows up when a user types `/`  |
 | USER       | 2    | A UI-based command that shows up when you right click or tap on a user    |
 | MESSAGE    | 3    | A UI-based command that shows up when you right click or tap on a message |
+
+###### Application Integration Types
+
+| Name          | Type | Description                                                               |
+| ------------- | ---- | ------------------------------------------------------------------------- |
+| GUILD_INSTALL | 0    | Available to be used in guilds                                            |
+| USER_INSTALL  | 1    | Available to be used in a user-app context                                |
 
 ###### Application Command Option Structure
 
@@ -89,7 +97,7 @@ All options have names, and an option can either be a parameter and input value-
 
 ## Application Command Index Object
 
-Multiple different resources are queryable with the application command index structure, including channels, guilds, and applications themselves.
+Multiple different resources are queryable with the application command index structure, including guilds and applications themselves. Sometimes usable with channels.
 
 ###### Application Command Index Structure
 

--- a/pages/interactions/application-commands.mdx
+++ b/pages/interactions/application-commands.mdx
@@ -87,6 +87,20 @@ All options have names, and an option can either be a parameter and input value-
 | value?   | [application command option type](#application-command-option-type)                                            | the value of the pair                                                        |
 | options? | array of [application command interaction data option](#application-command-interaction-data-option-structure) | present if this option is a group or subcommand                              |
 
+## Application Command Index Object
+
+Multiple different resources are queryable with the application command index structure, including channels, guilds, and applications themselves.
+
+###### Application Command Index Structure
+
+| Field                      | Type                                                                                                     | Description                                                             |
+| -------------------------- | -------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| applications               | array[[partial application](/resources/application#partial-application-structure) object]                | List of partial application(s) relevant to the requested resource       |
+| application-commands ^1^   | array[[application command](/interactions/application-commands#application-command-structure) object]    | List of application commands                                            |
+| version                    | snowflake                                                                                                | Snowflake representing when commands were last updated                  |
+
+^1^ This field will sometimes be an empty array when requested via [Get Application Command Index](#get-application-command-index) even if the application has registered global commmands. For more reliability, actual global commands should be obtained via [Get Global Application Commands](#get-global-application-commands).
+
 ## Authorizing Your Application
 
 Application commands do not depend on a bot user in the guild; they use the [interactions](/interactions/receiving-and-responding/) model. To create commands in a guild, your app must be authorized with the `applications.commands` scope.
@@ -865,9 +879,15 @@ When someone uses a message command, your application will receive an interactio
 
 ### Endpoints
 
+<RouteHeader method="GET" url="/applications/{application.id}/application-command-index">
+  Get Application Commands Index
+</RouteHeader>
+
+Returns an [Application Command Index](#application-command-index-object) object.
+
 <Alert type="info">
 
-For authorization, all endpoints take either a [bot token](/reference#authentication) or [client credentials token](/topics/oauth2#client-credentials-grant) for your application
+For authorization, all subsequent endpoints take either a [bot token](/reference#authentication) or [client credentials token](/topics/oauth2#client-credentials-grant) for your application
 
 </Alert>
 
@@ -875,15 +895,7 @@ For authorization, all endpoints take either a [bot token](/reference#authentica
   Get Global Application Commands
 </RouteHeader>
 
-<RouteHeader method="GET" url="/applications/{application.id}/commands">
-  Get Global Application Commands
-</RouteHeader>
-
-Fetch all of the global commands for your application. Returns an array of [application command](#application-command-object) objects.
-
-<RouteHeader method="POST" url="/applications/{application.id}/commands">
-  Create Global Application Command
-</RouteHeader>
+Fetch all of the global commands for your application. This endpoint can also be used with a user token as authorization for public applications. Returns an array of [application command](#application-command-object) objects.
 
 <RouteHeader method="POST" url="/applications/{application.id}/commands">
   Create Global Application Command

--- a/pages/resources/guild.mdx
+++ b/pages/resources/guild.mdx
@@ -1324,6 +1324,12 @@ Returns a partial [guild](#guild-object) object for the given guild ID. If the u
 
 Returns a partial [guild](#guild-object) object for the given guild ID with all partial fields. If the user is not in the guild, the guild must be discoverable.
 
+<RouteHeader method="GET" url="/guilds/{guild.id}/application-command-index">
+  Get Guild Application Command Index
+</RouteHeader>
+
+Returns an [Application Command Index](/interactions/application-commands#application-command-index-object) object containing all guild applications and their application commands. Includes guild-specific commands.
+
 <RouteHeader method="PATCH" url="/guilds/{guild.id}" supportsAuditReason mfa>
   Modify Guild
 </RouteHeader>


### PR DESCRIPTION
fixes some duplication typos present earlier on the application page as well

Will sync to latest before merge considering the family center PR is still open