### PR TITLE
route: /guilds/#{guild_id}/premium/subscriptions

### DIFF
--- a/pages/resources/guild.mdx
+++ b/pages/resources/guild.mdx
@@ -1370,7 +1370,7 @@ A premium subscription represents a member's premium subscription ([boost](https
 | user_id           | snowflake                                                         | The ID of the user this subscription is for                         |
 | ended             | boolean                                                           | If this premium subscription has ended                              |
 | pause_ends_at ^1^ | ?ISO8601 timestamp                                                | The timestamp for when this user's premium subscription will expire |
-| user              | partial partial [user](/resources/user#user-object) object        | The user this subscription is for                                   |
+| user              | partial [user](/resources/user#user-object) object                | The user this subscription is for                                   |
 
 ^1^ This field will be null in most cases, but it may be set to a timestamp in cases where the user's premium subscription is expiring.
 
@@ -1385,8 +1385,8 @@ A premium subscription represents a member's premium subscription ([boost](https
   "pause_ends_at": null,
   "user": {
     "id": "852892297661906993",
-    "username": "Alien",
-    "global_name": "alien",
+    "username": "alien",
+    "global_name": "Alien",
     "avatar": "568cc8b441a61e6b75307cac380bcc58",
     "avatar_decoration_data": {
       "asset": "a_e72e44eeea89e92dc02c9bec8b02d158",

--- a/pages/resources/guild.mdx
+++ b/pages/resources/guild.mdx
@@ -1357,7 +1357,7 @@ Defines the criteria used to satisfy Onboarding constraints that are required fo
 }
 ```
 
-###### Premium Subscription object
+###### Premium Subscription Object
 
 A premium subscription represents a member's premium subscription ([boost](https://support.discord.com/hc/en-us/sections/360007875211-Server-Boosting)) in a guild.
 

--- a/pages/resources/guild.mdx
+++ b/pages/resources/guild.mdx
@@ -1357,44 +1357,44 @@ Defines the criteria used to satisfy Onboarding constraints that are required fo
 }
 ```
 
-### Premium Subscription Object
+### Premium Guild Subscription Object
 
-Represents a member's premium subscription ([boost](https://support.discord.com/hc/en-us/sections/360007875211-Server-Boosting)) in a guild.
+Represents a member's premium guild subscription ([boost](https://support.discord.com/hc/en-us/sections/360007875211-Server-Boosting)).
 
-###### Premium Subscription Structure
+###### Premium Guild Subscription Structure
 
-| Field             | Type                                                              | Description                                                         |
-| ----------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
-| id                | snowflake                                                         | The ID of the premium guild subscription                                          |
-| guild_id          | snowflake                                                         | The ID of the guild this subscription is for                        |
-| user_id           | snowflake                                                         | The ID of the user who created the subscription                         |
-| ended             | boolean                                                           | If this subscription has ended                              |
-| ends_at? | ISO8601 timestamp | When this subscription will expire |
-| pause_ends_at | ?ISO8601 timestamp                                                | When the user's overall subscription pause will end, reactivating the premium guild subscription |
-| user              | partial [user](/resources/user#user-object) object                | The user this subscription is for                                   |
+| Field             | Type                                                              | Description                                                                                      |
+| ----------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | 
+| id                | snowflake                                                         | The ID of the premium guild subscription                                                         |
+| guild_id          | snowflake                                                         | The ID of the guild this subscription is for                                                     |
+| user_id           | snowflake                                                         | The ID of the user who created this premium guild subscription                                   |
+| ended             | boolean                                                           | If this premium guild subscription has ended                                                     |
+| ends_at?          | ISO8601 timestamp                                                 | When this premium guild subscription will expire                                                 |
+| pause_ends_at     | ?ISO8601 timestamp                                                | When the user's overall subscription pause will end, reactivating the premium guild subscription |
+| user              | partial [user](/resources/user#user-object) object                | The user this premium guild subscription is for                                                  |
 
-###### Example Premium Subscription
+###### Example Premium Guild Subscription
 
 ```json
 {
-  "id": "603376323175383060",
-  "user_id": "852892297661906993",
-  "guild_id": "574093012620279818",
+  "id": "1315132642890350602",
+  "user_id": "673658900435697665",
+  "guild_id": "1081635484209520802",
   "ended": false,
   "pause_ends_at": null,
   "user": {
-    "id": "852892297661906993",
-    "username": "alien",
-    "global_name": "Alien",
-    "avatar": "568cc8b441a61e6b75307cac380bcc58",
+    "id": "673658900435697665",
+    "username": "android",
+    "global_name": "Android",
+    "avatar": "08f104f8d5406c4d46916794fe2efeb7",
     "avatar_decoration_data": {
-      "asset": "a_e72e44eeea89e92dc02c9bec8b02d158",
-      "sku_id": "1245087724265013299",
+      "asset": "a_8552f9857793aed0cf816f370e2df3be",
+      "sku_id": "1232071712695386162",
       "expires_at": null
     },
     "collectibles": null,
     "discriminator": "0",
-    "public_flags": 136,
+    "public_flags": 4194560,
     "primary_guild": null,
     "clan": null
   }
@@ -2696,7 +2696,7 @@ Signs up the user for the student hub waitlist. The user will get an email and s
 ```
 
 <RouteHeader method="GET" url="/guilds/{guild.id}/premium/subscriptions">
-  Get Guild Premium Subscribers
+  Get Premium Guild Subscriptions
 </RouteHeader>
 
-Returns a list of [premium subscription](#premium-subscription-object) objects for the guild.
+Returns a list of [premium guild subscription](#premium-guild-subscription-object) objects for the guild.

--- a/pages/resources/guild.mdx
+++ b/pages/resources/guild.mdx
@@ -1357,7 +1357,7 @@ Defines the criteria used to satisfy Onboarding constraints that are required fo
 }
 ```
 
-###### Premium Subscription Object
+### Premium Subscription Object
 
 A premium subscription represents a member's premium subscription ([boost](https://support.discord.com/hc/en-us/sections/360007875211-Server-Boosting)) in a guild.
 

--- a/pages/resources/guild.mdx
+++ b/pages/resources/guild.mdx
@@ -1359,20 +1359,19 @@ Defines the criteria used to satisfy Onboarding constraints that are required fo
 
 ### Premium Subscription Object
 
-A premium subscription represents a member's premium subscription ([boost](https://support.discord.com/hc/en-us/sections/360007875211-Server-Boosting)) in a guild.
+Represents a member's premium subscription ([boost](https://support.discord.com/hc/en-us/sections/360007875211-Server-Boosting)) in a guild.
 
 ###### Premium Subscription Structure
 
 | Field             | Type                                                              | Description                                                         |
 | ----------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
-| id                | snowflake                                                         | The ID of the subscription                                          |
+| id                | snowflake                                                         | The ID of the premium guild subscription                                          |
 | guild_id          | snowflake                                                         | The ID of the guild this subscription is for                        |
-| user_id           | snowflake                                                         | The ID of the user this subscription is for                         |
-| ended             | boolean                                                           | If this premium subscription has ended                              |
-| pause_ends_at ^1^ | ?ISO8601 timestamp                                                | The timestamp for when this user's premium subscription will expire |
+| user_id           | snowflake                                                         | The ID of the user who created the subscription                         |
+| ended             | boolean                                                           | If this subscription has ended                              |
+| ends_at? | ISO8601 timestamp | When this subscription will expire |
+| pause_ends_at | ?ISO8601 timestamp                                                | When the user's overall subscription pause will end, reactivating the premium guild subscription |
 | user              | partial [user](/resources/user#user-object) object                | The user this subscription is for                                   |
-
-^1^ This field will be null in most cases, but it may be set to a timestamp in cases where the user's premium subscription is expiring.
 
 ###### Example Premium Subscription
 
@@ -2700,4 +2699,4 @@ Signs up the user for the student hub waitlist. The user will get an email and s
   Get Guild Premium Subscribers
 </RouteHeader>
 
-Returns an array of [premium subscription](#premium-subscription-object) objects for the guild.
+Returns a list of [premium subscription](#premium-subscription-object) objects for the guild.

--- a/pages/resources/guild.mdx
+++ b/pages/resources/guild.mdx
@@ -1357,6 +1357,51 @@ Defines the criteria used to satisfy Onboarding constraints that are required fo
 }
 ```
 
+###### Premium Subscription object
+
+A premium subscription represents a member's premium subscription ([boost](https://support.discord.com/hc/en-us/sections/360007875211-Server-Boosting)) in a guild.
+
+###### Premium Subscription Structure
+
+| Field             | Type                                                              | Description                                                         |
+| ----------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
+| id                | snowflake                                                         | The ID of the subscription                                          |
+| guild_id          | snowflake                                                         | The ID of the guild this subscription is for                        |
+| user_id           | snowflake                                                         | The ID of the user this subscription is for                         |
+| ended             | boolean                                                           | If this premium subscription has ended                              |
+| pause_ends_at ^1^ | ?ISO8601 timestamp                                                | The timestamp for when this user's premium subscription will expire |
+| user              | partial partial [user](/resources/user#user-object) object        | The user this subscription is for                                   |
+
+^1^ This field will be null in most cases, but it may be set to a timestamp in cases where the user's premium subscription is expiring.
+
+###### Example Premium Subscription
+
+```json
+{
+  "id": "603376323175383060",
+  "user_id": "852892297661906993",
+  "guild_id": "574093012620279818",
+  "ended": false,
+  "pause_ends_at": null,
+  "user": {
+    "id": "852892297661906993",
+    "username": "Alien",
+    "global_name": "alien",
+    "avatar": "568cc8b441a61e6b75307cac380bcc58",
+    "avatar_decoration_data": {
+      "asset": "a_e72e44eeea89e92dc02c9bec8b02d158",
+      "sku_id": "1245087724265013299",
+      "expires_at": null
+    },
+    "collectibles": null,
+    "discriminator": "0",
+    "public_flags": 136,
+    "primary_guild": null,
+    "clan": null
+  }
+}
+```
+
 ## Endpoints
 
 <RouteHeader method="GET" url="/users/@me/guilds" supportsOAuth2="guilds">
@@ -2650,3 +2695,9 @@ Signs up the user for the student hub waitlist. The user will get an email and s
   "school": "discord"
 }
 ```
+
+<RouteHeader method="GET" url="/guilds/{guild.id}/premium/subscriptions">
+  Get Guild Premium Subscribers
+</RouteHeader>
+
+Returns an array of [premium subscription](#premium-subscription-object) objects for the guild.


### PR DESCRIPTION
## Summary

This PR documents the premium subscription object (is that what it's called?), and adds the `/guilds/{guild.id}/premium/subscriptions` route which can be used to fetch a list of premium subscribers for a guild.