### PR TITLE
Added channel unread update event

### DIFF
--- a/pages/topics/gateway-events.mdx
+++ b/pages/topics/gateway-events.mdx
@@ -1152,7 +1152,7 @@ Sent when a channel relevant to the current user is deleted. The inner payload i
 
 Sent when guild channels unread statuses are updated.
 
-###### Channel unread update structure
+###### Channel unread update event structure
 
 | Field | Type | Description |
 | --- | --- | --- |

--- a/pages/topics/gateway-events.mdx
+++ b/pages/topics/gateway-events.mdx
@@ -708,6 +708,7 @@ These events directly correspond with a specific action or state change that has
 | [Channel Create](#channel-create)                                                   | New guild channel created                                                                       |
 | [Channel Update](#channel-update)                                                   | Channel was updated                                                                             |
 | [Channel Delete](#channel-delete)                                                   | Channel was deleted                                                                             |
+| [Channel unread update](#channel-unread-update)                                     | Guild channels unread status was updated                                                        |
 | [Channel Statuses](#channel-statuses)                                               | Response to [Request Channel Statuses](#request-channel-statuses)                               |
 | [Voice Channel Status Update](#voice-channel-status-update)                         | Voice channel status was updated                                                                |
 | [Channel Pins Update](#channel-pins-update)                                         | Message was pinned or unpinned                                                                  |
@@ -1146,6 +1147,25 @@ This event may reference roles or guild members that no longer exist in a guild.
 #### Channel Delete
 
 Sent when a channel relevant to the current user is deleted. The inner payload is a [channel](/resources/channel#channel-object) object.
+
+#### Channel unread update
+
+Sent when guild channels unread statuses are updated.
+
+###### Channel unread update structure
+
+| Field | Type | Description |
+| --- | --- | --- |
+| guild_id | snowflake | The ID of the guild |
+| channel_unread_updates | array[[channel unread update](#channel-unread-update-structure) object] | The updated channel unread counts |
+
+###### Channel unread update structure
+
+| Field | Type | Description |
+| --- | --- | --- |
+| id | snowflake | The ID of the channel |
+| last_pin_timestamp | ?ISO8601 timestamp | When the most recent pinned message was pinned |
+| last_message_id | ?snowflake | The ID of the most recent message in the channel |
 
 #### Channel Statuses
 


### PR DESCRIPTION
I just received for the first time a `CHANNEL_UNREAD_UPDATE` in my client and it was not in the doc so here we are. I wasn't able to find any documentation about this event so i hope it's accurate.

I saved a sample here if you want to double check: [event.json](https://github.com/user-attachments/files/19409781/event2.json)
