### PR TITLE
fix: typo

### DIFF
--- a/pages/resources/guild.mdx
+++ b/pages/resources/guild.mdx
@@ -1954,7 +1954,7 @@ Returns a list of [supplemental guild member](#supplemental-guild-member-object)
 | ----- | ---------------- | ------------------------------------------------------------------------- |
 | users | array[snowflake] | The user IDs to fetch supplemental guild member information for (max 200) |
 
-<RouteHeader method="GET" url="/guilds/{guild.id>/members/unusual-dm-activity">
+<RouteHeader method="GET" url="/guilds/{guild.id}/members/unusual-dm-activity">
   Get Guild Members With Unusual DM Activity
 </RouteHeader>
 


### PR DESCRIPTION
This PR fixes a tiny typo in a route where a `>` should be a `}`, I think