### PR TITLE
Update OAuth2 device authorization URLs

### DIFF
--- a/pages/topics/oauth2.mdx
+++ b/pages/topics/oauth2.mdx
@@ -690,7 +690,7 @@ This endpoint is only usable with an OAuth2 access token with the `openid` scope
 }
 ```
 
-<RouteHeader method="POST" url="/oauth2/authorize/device" unauthenticated>
+<RouteHeader method="POST" url="/oauth2/device/authorize" unauthenticated>
   Get OAuth2 Device Code
 </RouteHeader>
 


### PR DESCRIPTION
- Updated sample code uri from `/oauth2/authorize/device` to `/oauth2/device/authorize`
- Updated in the OAuth2 URLs table from `https://discord.com/oauth2/authorize/device` to `https://discord.com/activate`