### PR TITLE
Clarify optional fields when creating a GSE exception

### DIFF
--- a/pages/resources/guild-scheduled-event.mdx
+++ b/pages/resources/guild-scheduled-event.mdx
@@ -507,7 +507,7 @@ Creates an exception to the recurrence rule for a guild scheduled event. Returns
 | scheduled_start_time? ^1^     | ?ISO8601 timestamp | The scheduled event's modified start time for this recurrence     |
 | scheduled_end_time? ^1^       | ?ISO8601 timestamp | The scheduled event's modified end time for this recurrence       |
 
-^1^ At minimum, you must provide a value for one of `is_canceled`, `scheduled_start_time`, or `scheduled_end_time`. Otherwise, the request will fail with an error (`180005`).
+^1^ At minimum, you must provide a value for one of `is_canceled`, `scheduled_start_time`, or `scheduled_end_time`. Otherwise, the request will fail with an [`180005` JSON error code](/topics/opcodes-and-status-codes#json-error-codes).
 
 <RouteHeader
   method="PATCH"


### PR DESCRIPTION
I'm not sure how necessary this sort of change is, but the error message when you omit all three of the fields below can be a little vague, so it might be nice to clarify this behavior