### PR TITLE
remove version info links for web as they no longer exist

### DIFF
--- a/pages/topics/client-distribution.mdx
+++ b/pages/topics/client-distribution.mdx
@@ -22,13 +22,11 @@ Discord offers a web client that can be used in a browser. This same web client 
 
 ###### Web Release Channel
 
-The JSON files linked below contain the `hash` of the latest client build for the respective release channel, as well as whether the update is `required`.
-
-| Value      | URL                            | Description       | Version Info                                                                           |
-| ---------- | ------------------------------ | ----------------- | -------------------------------------------------------------------------------------- |
-| stable     | https://discord.com/app        | Stable build      | [`/assets/version.stable.json`](https://discord.com/assets/version.stable.json)        |
-| ptb ^1^    | https://ptb.discord.com/app    | Public test build | [`/assets/version.ptb.json`](https://ptb.discord.com/assets/version.ptb.json)          |
-| canary ^1^ | https://canary.discord.com/app | Alpha test build  | [`/assets/version.canary.json`](https://canary.discord.com/assets/version.canary.json) |
+| Value      | URL                            | Description       |
+| ---------- | ------------------------------ | ----------------- |
+| stable     | https://discord.com/app        | Stable build      | 
+| ptb ^1^    | https://ptb.discord.com/app    | Public test build | 
+| canary ^1^ | https://canary.discord.com/app | Alpha test build  |
 
 ^1^ See the [Help Center article](https://support.discord.com/hc/en-us/articles/360035675191-Discord-Testing-Clients) for more information on Discord testing clients.
 


### PR DESCRIPTION
Discord removed these files:
https://canary.discord.com/assets/version.canary.json
https://ptb.discord.com/assets/version.ptb.json
https://discord.com/assets/version.stable.json