### PR TITLE
Document Hour-Old Message Edit Limits

### DIFF
--- a/pages/resources/message.mdx
+++ b/pages/resources/message.mdx
@@ -2212,6 +2212,12 @@ Starting with API v10, the `attachments` array must contain all attachments that
 
 </Alert>
 
+<Alert type="info">
+
+Messages older than 1 hour may only be edited 3 times per 6-second window per channel.
+
+</Alert>
+
 ###### JSON/Form Params
 
 | Field             | Type                                                                       | Description                                                                                    |


### PR DESCRIPTION
Documents the message editing limit for hour-old messages.

Exceeding this limit raises 30046: Maximum number of edits to messages older than 1 hour reached.