### PR TITLE
feat(deploy): use `workflow_run` instead of `pull_request_target`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,57 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+
+# Runs do not need to be concurrent
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Run if
+    # - event == 'push'
+    # - event == 'pull_request' && origin_repo != project_repo (i.e. a fork)
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+
+    name: Build
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 23
+          cache: pnpm
+
+      - name: Restore Search Index Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            public/search-index.json
+            public/search-vectors.bin
+            public/search-index.hash
+          key: search-index-${{ github.run_id }}
+          restore-keys: search-index-
+
+      - name: Install and Build Artifacts
+        env:
+          VITE_ERROR_CODES_ENDPOINT: ${{ vars.VITE_ERROR_CODES_ENDPOINT }}
+        run: |
+          pnpm install --frozen-lockfile --production=false
+          pnpm build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: vite-dist
+          path: dist/

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,19 +23,19 @@ jobs:
     name: Build
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 23
           cache: pnpm
 
       - name: Restore Search Index Cache
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: |
             public/search-index.json
@@ -51,7 +51,7 @@ jobs:
           pnpm install --frozen-lockfile --production=false
           pnpm build
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: vite-dist
           path: dist/

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -47,19 +47,19 @@ jobs:
             output deploy_branch "$BRANCH"
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 23
           cache: pnpm
 
       - name: Download Build Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: vite-dist
           run-id: ${{ github.event.workflow_run.id }}
@@ -75,7 +75,7 @@ jobs:
 
       - name: Deploy Site
         id: deploy
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,25 +1,52 @@
 name: Deploy
 
 on:
-  push:
-  pull_request_target:
+  workflow_run:
+    workflows: [Build]
+    types:
+      - completed
 
 # Runs do not need to be concurrent
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
+  deployments: write
 
 jobs:
   deploy:
-    permissions:
-      deployments: write
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
 
-    if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-
-    runs-on: blacksmith-4vcpu-ubuntu-2404
     name: Deploy
 
     steps:
+      - name: Setup Variables
+        id: vars
+        shell: bash
+        run: |
+          # WARNING:
+          # use '...' especially when using github templating
+          # only use "..." when using bash variable references
+
+          output() {
+            echo "$1='$2'" >> "$GITHUB_OUTPUT"
+          }
+
+          EVENT='${{ github.event.workflow_run.event }}'
+          BRANCH='${{ github.event.workflow_run.head_branch }}'
+
+          output event "$EVENT"
+          output branch "$BRANCH"
+
+          if [[ "$EVENT" == "pull_request" ]]; then
+            output deploy_branch 'pr-${{ github.event.workflow_run.pull_requests[0].number }}'
+          else
+            output deploy_branch "$BRANCH"
+          fi
+
       - uses: actions/checkout@v4
 
       - name: Install pnpm
@@ -31,36 +58,20 @@ jobs:
           node-version: 23
           cache: pnpm
 
-      - name: Export Environment Variables
-        uses: infovista-opensource/vars-to-env-action@2.0.0
+      - name: Download Build Artifacts
+        uses: actions/download-artifact@v4
         with:
-          secrets: ${{ toJSON(vars) }}
+          name: vite-dist
+          run-id: ${{ github.event.workflow_run.id }}
 
-      - name: Restore search index cache
-        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-        uses: actions/cache@v4
-        with:
-          path: |
-            public/search-index.json
-            public/search-vectors.bin
-            public/search-index.hash
-          key: search-index-${{ github.run_id }}
-          restore-keys: search-index-
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile --production=false
 
-      - name: Install and Build Artifacts
+      - name: Build Search Index
+        if: steps.vars.outputs.event == 'push' && steps.vars.outputs.branch == 'master'
         env:
-          GEMINI_API_KEY: ${{ github.ref == 'refs/heads/master' && secrets.GEMINI_API_KEY || '' }}
-        run: |
-          # Prevent supply chain attack by installing packages before pulling PR
-          pnpm install --frozen-lockfile --production=false
-
-          # Pull the PR branch if necessary
-          if [ "${{ github.event_name }}" == "pull_request_target" ]; then
-            git fetch origin "pull/${{ github.event.number }}/head:pull/${{ github.event.number }}/head"
-            git switch "pull/${{ github.event.number }}/head"
-          fi
-
-          pnpm build
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: pnpm build:search
 
       - name: Deploy Site
         id: deploy
@@ -68,88 +79,20 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy --branch ${{ github.event_name == 'pull_request_target' && format('pr-{0}', github.event.number) || github.ref_name }}
+          command: pages deploy --branch ${{ steps.vars.outputs.deploy_branch }}
 
       - name: Notify Deployment
-        uses: actions/github-script@v7
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
           PROJECT_NAME: "discord-userdoccers"
 
-          DEPLOYMENT_DESCRIPTION: ${{ github.event_name == 'push' &&  github.event.head_commit.message || github.event.pull_request.title }}
-        with:
-          script: |
-            const { CLOUDFLARE_ACCOUNT_ID, PROJECT_NAME } = process.env;
+          DEPLOYMENT_ENVIRONMENT: ${{ steps.deploy.outputs.pages-environment }}
 
-            const DEPLOYMENT_ENVIRONMENT = "${{ steps.deploy.outputs.pages-environment }}";
-            const DEPLOYMENT_URL = "${{ steps.deploy.outputs.deployment-url }}";
-            const DEPLOYMENT_ALIAS_URL = "${{ steps.deploy.outputs.pages-deployment-alias-url }}" || "https://docs.discord.food";
-            const DEPLOYMENT_ID = "${{ steps.deploy.outputs.pages-deployment-id }}";
-            const DEPLOYMENT_DESCRIPTION = process.env.DEPLOYMENT_DESCRIPTION;
-
-            const envConfig = {
-              production: {
-                environment: "Production",
-                production: true,
-                description: DEPLOYMENT_DESCRIPTION,
-              },
-              preview: {
-                environment: "Preview",
-                production: false,
-                description: DEPLOYMENT_DESCRIPTION,
-              },
-            };
-
-            const { environment, production: production_environment, description } = envConfig[DEPLOYMENT_ENVIRONMENT];
-
-            const deploymentRef = context.eventName === "pull_request_target"
-              ? context.payload.pull_request.head.sha
-              : context.sha;
-
-            const deployment = await github.rest.repos.createDeployment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: deploymentRef,
-              environment,
-              production_environment,
-              description,
-              required_contexts: [],
-              auto_merge: false,
-              payload: context.eventName === "pull_request_target"
-                        ? { pull_request: context.payload.number }
-                        : { }
-            });
-
-            if (deployment.status !== 201) {
-              core.error(deployment.data.message ?? "error creating deployment", {
-                title: "Deployment Failed",
-              });
-
-              return;
-            }
-
-            await github.rest.repos.createDeploymentStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              environment,
-              production_environment,
-              description,
-              deployment_id: deployment.data.id,
-              environment_url: DEPLOYMENT_URL,
-              log_url: `https://dash.cloudflare.com/${CLOUDFLARE_ACCOUNT_ID}/pages/view/${PROJECT_NAME}/${DEPLOYMENT_ID}`,
-              state: "success",
-              auto_inactive: false,
-            });
-
-            await core.summary
-              .addRaw(
-                `# ${environment} Deployment
-
-            | Name                           | Result                  |
-            | ------------------------------ | ----------------------- |
-            | **Last commit:**               | ${deploymentRef}        |
-            | **${environment} URL**:        | ${DEPLOYMENT_URL}       |
-            | **Branch ${environment} URL**: | ${DEPLOYMENT_ALIAS_URL} |`,
-              )
-              .write();
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment-url }}
+          DEPLOYMENT_ALIAS_URL: ${{ steps.deploy.outputs.pages-deployment-alias-url || 'https://docs.discord.food' }}
+          DEPLOYMENT_ID: ${{ steps.deploy.outputs.pages-deployment-id }}
+        run: pnpm run ci:deploy
+            

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
 
       - name: Install Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 23
           cache: pnpm
@@ -43,13 +43,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
 
       - name: Install Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 23
           cache: pnpm
@@ -68,13 +68,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
 
       - name: Install Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 23
           cache: pnpm
@@ -93,13 +93,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
 
       - name: Install Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 23
           cache: pnpm

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,16 +1,21 @@
 name: Testing
-on: [push, pull_request]
+
+on: 
+  push:
+  pull_request:
 
 # Runs do not need to be concurrent
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   lint:
-    name: ESLint
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+
+    name: ESLint
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -31,9 +36,11 @@ jobs:
         run: pnpm run lint
 
   prettier:
-    name: Prettier
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+
+    name: Prettier
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -54,9 +61,11 @@ jobs:
         run: pnpm run prettier
 
   typescript:
-    name: TypeScript
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+
+    name: TypeScript
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -77,9 +86,11 @@ jobs:
         run: pnpm exec tsc --noEmit
 
   links:
-    name: Check Links
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+
+    name: Check Links
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/ci/deploySite.ts
+++ b/ci/deploySite.ts
@@ -1,0 +1,148 @@
+import { error, summary } from "@actions/core";
+import { context, getOctokit } from "@actions/github";
+import type { WorkflowRunCompletedEvent } from "@octokit/webhooks-types";
+
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      GITHUB_TOKEN: string;
+
+      CLOUDFLARE_ACCOUNT_ID: string;
+
+      PROJECT_NAME: string;
+
+      DEPLOYMENT_ENVIRONMENT: "production" | "preview";
+
+      DEPLOYMENT_URL: string;
+      DEPLOYMENT_ALIAS_URL: string;
+      DEPLOYMENT_ID: string;
+    }
+  }
+}
+
+const {
+  GITHUB_TOKEN,
+
+  CLOUDFLARE_ACCOUNT_ID,
+
+  PROJECT_NAME,
+
+  DEPLOYMENT_ENVIRONMENT,
+
+  DEPLOYMENT_URL,
+  DEPLOYMENT_ALIAS_URL,
+  DEPLOYMENT_ID,
+} = process.env;
+
+const ENV_CONF = {
+  production: {
+    environment: "Production",
+    production_environment: true,
+  },
+  preview: {
+    environment: "Preview",
+    production_environment: false,
+  },
+};
+
+async function getMetadata(github: ReturnType<typeof getOctokit>) {
+  const {
+    workflow_run: { event, head_commit, head_sha, pull_requests },
+  } = context.payload as WorkflowRunCompletedEvent;
+
+  if (event == "pull_request") {
+    const [
+      {
+        head: { sha },
+        number,
+      },
+    ] = pull_requests;
+
+    const pr = await github.rest.pulls.get({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      pull_number: number,
+    });
+
+    if (pr.status != 200) {
+      error(pr.data.message ?? "error fetching PR", { title: "Fetching PR Failed" });
+
+      process.exit(1);
+    }
+
+    return {
+      ref: sha,
+      payload: { pull_request: number },
+      description: pr.data.pullRequest.title,
+    };
+  }
+
+  return {
+    ref: head_sha,
+    payload: {},
+    description: head_commit.message,
+  };
+}
+
+async function main() {
+  if (!["production", "preview"].includes(DEPLOYMENT_ENVIRONMENT)) {
+    error('expected DEPLOYMENT_ENVIRONMENT to be one of ("production", "preview")', {
+      title: "Invalid Environment",
+    });
+
+    return 1;
+  }
+
+  const github = getOctokit(GITHUB_TOKEN);
+
+  const { environment, production_environment } = ENV_CONF[DEPLOYMENT_ENVIRONMENT];
+
+  const { ref, payload, description } = await getMetadata(github);
+
+  const deployment = await github.rest.repos.createDeployment({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    ref,
+    environment,
+    production_environment,
+    description,
+    required_contexts: [],
+    auto_merge: false,
+    payload,
+  });
+
+  if (deployment.status !== 201) {
+    error(deployment.data.message ?? "error creating deployment", { title: "Deployment Failed" });
+
+    return 1;
+  }
+
+  await github.rest.repos.createDeploymentStatus({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    environment,
+    production_environment,
+    description,
+    deployment_id: deployment.data.id,
+    environment_url: DEPLOYMENT_URL,
+    log_url: `https://dash.cloudflare.com/${CLOUDFLARE_ACCOUNT_ID}/pages/view/${PROJECT_NAME}/${DEPLOYMENT_ID}`,
+    state: "success",
+    auto_inactive: false,
+  });
+
+  await summary
+    .addRaw(
+      `# ${environment} Deployment
+
+| Name                           | Result                  |
+| ------------------------------ | ----------------------- |
+| **Last commit:**               | ${ref}                  |
+| **${environment} URL**:        | ${DEPLOYMENT_URL}       |
+| **Branch ${environment} URL**: | ${DEPLOYMENT_ALIAS_URL} |`,
+    )
+    .write();
+
+  return 0;
+}
+
+process.exit(await main());

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "pnpm run prebuild && pnpm vite-react-ssg dev",
-    "build": "pnpm run prebuild && pnpm run prebuild:search && pnpm vite-react-ssg build",
+    "build": "pnpm run prebuild && pnpm vite-react-ssg build",
     "preview": "vite preview",
     "prebuild": "node --experimental-strip-types ci/sitemap.ts",
     "prebuild:search": "node --experimental-strip-types ci/buildSearchIndex.ts",
@@ -15,7 +15,8 @@
     "prepare": "husky || true",
     "prettier": "prettier -c **/*.mdx **/*.ts{,x}",
     "prettier:fix": "prettier --write **/*.mdx **/*.ts{,x}",
-    "test:links": "node --experimental-strip-types ci/checkLinks.ts"
+    "test:links": "node --experimental-strip-types ci/checkLinks.ts",
+    "ci:deploy": "node --experimental-strip-types ci/deploySite.ts"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.10",
@@ -29,9 +30,11 @@
   },
   "devDependencies": {
     "@actions/core": "^3.0.1",
+    "@actions/github": "^9.1.1",
     "@eslint/eslintrc": "^3.3.5",
     "@eslint/js": "^10.0.1",
     "@mdx-js/rollup": "^3.1.1",
+    "@octokit/webhooks-types": "^7.6.1",
     "@tailwindcss/forms": "^0.5.11",
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@actions/core':
         specifier: ^3.0.1
         version: 3.0.1
+      '@actions/github':
+        specifier: ^9.1.1
+        version: 9.1.1
       '@eslint/eslintrc':
         specifier: ^3.3.5
         version: 3.3.5
@@ -45,6 +48,9 @@ importers:
       '@mdx-js/rollup':
         specifier: ^3.1.1
         version: 3.1.1(rollup@4.59.0)
+      '@octokit/webhooks-types':
+        specifier: ^7.6.1
+        version: 7.6.1
       '@tailwindcss/forms':
         specifier: ^0.5.11
         version: 0.5.11(tailwindcss@4.2.4)
@@ -143,6 +149,12 @@ packages:
 
   '@actions/exec@3.0.0':
     resolution: {integrity: sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==}
+
+  '@actions/github@9.1.1':
+    resolution: {integrity: sha512-tL5JbYOBZHc0ngEnCsaDcryUizIUIlQyIMwy1Wkx93H5HzbBJ7TbiPx2PnFjBwZW0Vh05JmfFZhecE6gglYegA==}
+
+  '@actions/http-client@3.0.2':
+    resolution: {integrity: sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA==}
 
   '@actions/http-client@4.0.0':
     resolution: {integrity: sha512-QuwPsgVMsD6qaPD57GLZi9sqzAZCtiJT8kVBCDpLtxhL5MydQ4gS+DrejtZZPdIYyB1e95uCK9Luyds7ybHI3g==}
@@ -387,6 +399,51 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@octokit/auth-token@6.0.0':
+    resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
+    engines: {node: '>= 20'}
+
+  '@octokit/core@7.0.6':
+    resolution: {integrity: sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==}
+    engines: {node: '>= 20'}
+
+  '@octokit/endpoint@11.0.3':
+    resolution: {integrity: sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==}
+    engines: {node: '>= 20'}
+
+  '@octokit/graphql@9.0.3':
+    resolution: {integrity: sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/openapi-types@27.0.0':
+    resolution: {integrity: sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==}
+
+  '@octokit/plugin-paginate-rest@14.0.0':
+    resolution: {integrity: sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0':
+    resolution: {integrity: sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/request-error@7.1.0':
+    resolution: {integrity: sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/request@10.0.10':
+    resolution: {integrity: sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w==}
+    engines: {node: '>= 20'}
+
+  '@octokit/types@16.0.0':
+    resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
+
+  '@octokit/webhooks-types@7.6.1':
+    resolution: {integrity: sha512-S8u2cJzklBC0FgTwWVLaM8tMrDuDMVE4xiTK4EYXM9GntyvrdbSoxqDQa+Fh57CCNApyIpyeqPhhFEmHPfrXgw==}
 
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
@@ -996,6 +1053,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  before-after-hook@4.0.0:
+    resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -1083,6 +1143,10 @@ packages:
 
   confbox@0.2.4:
     resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -1732,6 +1796,9 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json-with-bigint@3.5.8:
+    resolution: {integrity: sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -2669,6 +2736,9 @@ packages:
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
+  universal-user-agent@7.0.3:
+    resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
+
   universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
     engines: {node: '>= 4.0.0'}
@@ -2909,6 +2979,21 @@ snapshots:
   '@actions/exec@3.0.0':
     dependencies:
       '@actions/io': 3.0.2
+
+  '@actions/github@9.1.1':
+    dependencies:
+      '@actions/http-client': 3.0.2
+      '@octokit/core': 7.0.6
+      '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.6)
+      '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
+      '@octokit/request': 10.0.10
+      '@octokit/request-error': 7.1.0
+      undici: 6.23.0
+
+  '@actions/http-client@3.0.2':
+    dependencies:
+      tunnel: 0.0.6
+      undici: 6.23.0
 
   '@actions/http-client@4.0.0':
     dependencies:
@@ -3233,6 +3318,60 @@ snapshots:
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     optional: true
+
+  '@octokit/auth-token@6.0.0': {}
+
+  '@octokit/core@7.0.6':
+    dependencies:
+      '@octokit/auth-token': 6.0.0
+      '@octokit/graphql': 9.0.3
+      '@octokit/request': 10.0.10
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      before-after-hook: 4.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/endpoint@11.0.3':
+    dependencies:
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/graphql@9.0.3':
+    dependencies:
+      '@octokit/request': 10.0.10
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/openapi-types@27.0.0': {}
+
+  '@octokit/plugin-paginate-rest@14.0.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/types': 16.0.0
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/types': 16.0.0
+
+  '@octokit/request-error@7.1.0':
+    dependencies:
+      '@octokit/types': 16.0.0
+
+  '@octokit/request@10.0.10':
+    dependencies:
+      '@octokit/endpoint': 11.0.3
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      content-type: 2.0.0
+      json-with-bigint: 3.5.8
+      universal-user-agent: 7.0.3
+
+  '@octokit/types@16.0.0':
+    dependencies:
+      '@octokit/openapi-types': 27.0.0
+
+  '@octokit/webhooks-types@7.6.1': {}
 
   '@oxc-project/types@0.127.0': {}
 
@@ -3777,6 +3916,8 @@ snapshots:
 
   baseline-browser-mapping@2.10.0: {}
 
+  before-after-hook@4.0.0: {}
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -3858,6 +3999,8 @@ snapshots:
   confbox@0.1.8: {}
 
   confbox@0.2.4: {}
+
+  content-type@2.0.0: {}
 
   convert-source-map@2.0.0: {}
 
@@ -4682,6 +4825,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json-with-bigint@3.5.8: {}
 
   json5@2.2.3: {}
 
@@ -6023,6 +6168,8 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
+
+  universal-user-agent@7.0.3: {}
 
   universalify@0.2.0: {}
 


### PR DESCRIPTION
#359 served as a great stop gap solution and things have been robust ever since then
however the recent activity in the deploy workflow makes me uncomfortable and I'd
like to eliminate the usage of `pull_request_target` to prevent any unfortunate mistakes
in the future.

additionally I suggest

- updating minimum node version, this will remove the need for `--experimental-strip-types` in `package.json` scripts
- updating vite config to use `rolldownOptions` instead of the now deprecated `rollupOptions`

read commit message for additional details