### PR TITLE
Update Get Guild Members Supplemental json params

### DIFF
--- a/pages/resources/guild.mdx
+++ b/pages/resources/guild.mdx
@@ -567,14 +567,7 @@ A partial guild object returned from the [Get User Guilds](#get-user-guilds) end
     "banner": "bb42bdc37653b7cf58c4c8cc622e76cb",
     "owner": true,
     "permissions": "36953089",
-    "features": [
-      "COMMUNITY",
-      "NEWS",
-      "ANIMATED_ICON",
-      "INVITE_SPLASH",
-      "BANNER",
-      "ROLE_ICONS"
-    ],
+    "features": ["COMMUNITY", "NEWS", "ANIMATED_ICON", "INVITE_SPLASH", "BANNER", "ROLE_ICONS"],
     "approximate_member_count": 420,
     "approximate_presence_count": 69
   }
@@ -2099,8 +2092,8 @@ Returns a list of [supplemental guild member](#supplemental-guild-member-object)
 
 ###### JSON Params
 
-| Field    | Type             | Description                                                               |
-| -------- | ---------------- | ------------------------------------------------------------------------- |
+| Field | Type             | Description                                                               |
+| ----- | ---------------- | ------------------------------------------------------------------------- |
 | user_ids | array[snowflake] | The user IDs to fetch supplemental guild member information for (max 200) |
 
 <RouteHeader method="GET" url="/guilds/{guild.id}/members/unusual-dm-activity">
@@ -2809,7 +2802,7 @@ Returns a list of join requests for the guild for manual approval. Requires the 
 ###### Response Body
 
 | Field               | Type                                                    | Description                                            |
-| ------------------- | ------------------------------------------------------- | ------------------------------------------------------ |
+| --------------------| ------------------------------------------------------- | ------------------------------------------------------ |
 | guild_join_requests | array[[guild join request](#guild-join-request-object)] | The join requests for the guild                        |
 | total?              | integer                                                 | The total number of join requests that match the query |
 

--- a/pages/resources/guild.mdx
+++ b/pages/resources/guild.mdx
@@ -2094,7 +2094,7 @@ Returns a list of [supplemental guild member](#supplemental-guild-member-object)
 
 | Field | Type             | Description                                                               |
 | ----- | ---------------- | ------------------------------------------------------------------------- |
-| users | array[snowflake] | The user IDs to fetch supplemental guild member information for (max 200) |
+| user_ids | array[snowflake] | The user IDs to fetch supplemental guild member information for (max 200) |
 
 <RouteHeader method="GET" url="/guilds/{guild.id}/members/unusual-dm-activity">
   Get Guild Members With Unusual DM Activity

--- a/pages/resources/guild.mdx
+++ b/pages/resources/guild.mdx
@@ -567,7 +567,14 @@ A partial guild object returned from the [Get User Guilds](#get-user-guilds) end
     "banner": "bb42bdc37653b7cf58c4c8cc622e76cb",
     "owner": true,
     "permissions": "36953089",
-    "features": ["COMMUNITY", "NEWS", "ANIMATED_ICON", "INVITE_SPLASH", "BANNER", "ROLE_ICONS"],
+    "features": [
+      "COMMUNITY",
+      "NEWS",
+      "ANIMATED_ICON",
+      "INVITE_SPLASH",
+      "BANNER",
+      "ROLE_ICONS"
+    ],
     "approximate_member_count": 420,
     "approximate_presence_count": 69
   }
@@ -2092,8 +2099,8 @@ Returns a list of [supplemental guild member](#supplemental-guild-member-object)
 
 ###### JSON Params
 
-| Field | Type             | Description                                                               |
-| ----- | ---------------- | ------------------------------------------------------------------------- |
+| Field    | Type             | Description                                                               |
+| -------- | ---------------- | ------------------------------------------------------------------------- |
 | user_ids | array[snowflake] | The user IDs to fetch supplemental guild member information for (max 200) |
 
 <RouteHeader method="GET" url="/guilds/{guild.id}/members/unusual-dm-activity">
@@ -2802,7 +2809,7 @@ Returns a list of join requests for the guild for manual approval. Requires the 
 ###### Response Body
 
 | Field               | Type                                                    | Description                                            |
-| --------------------| ------------------------------------------------------- | ------------------------------------------------------ |
+| ------------------- | ------------------------------------------------------- | ------------------------------------------------------ |
 | guild_join_requests | array[[guild join request](#guild-join-request-object)] | The join requests for the guild                        |
 | total?              | integer                                                 | The total number of join requests that match the query |
 

--- a/pages/resources/guild.mdx
+++ b/pages/resources/guild.mdx
@@ -2092,8 +2092,8 @@ Returns a list of [supplemental guild member](#supplemental-guild-member-object)
 
 ###### JSON Params
 
-| Field | Type             | Description                                                               |
-| ----- | ---------------- | ------------------------------------------------------------------------- |
+| Field    | Type             | Description                                                               |
+| -------- | ---------------- | ------------------------------------------------------------------------- |
 | user_ids | array[snowflake] | The user IDs to fetch supplemental guild member information for (max 200) |
 
 <RouteHeader method="GET" url="/guilds/{guild.id}/members/unusual-dm-activity">
@@ -2802,7 +2802,7 @@ Returns a list of join requests for the guild for manual approval. Requires the 
 ###### Response Body
 
 | Field               | Type                                                    | Description                                            |
-| --------------------| ------------------------------------------------------- | ------------------------------------------------------ |
+| ------------------- | ------------------------------------------------------- | ------------------------------------------------------ |
 | guild_join_requests | array[[guild join request](#guild-join-request-object)] | The join requests for the guild                        |
 | total?              | integer                                                 | The total number of join requests that match the query |
 


### PR DESCRIPTION
Almost lost my mind trying to figure out why this endpoint wasn't working till I realized that it should be `user_ids` instead of `users`. (not sure when it changed or if it was always like this)