### PR TITLE
Document voice state connected_at

### DIFF
--- a/pages/resources/voice.mdx
+++ b/pages/resources/voice.mdx
@@ -16,7 +16,7 @@ Used to represent a user's voice connection status.
 | user_id                    | snowflake                                                   | The user ID this voice state is for                                     |
 | member? ^1^                | [guild member](/resources/guild#guild-member-object) object | The guild member this voice state is for                                |
 | session_id                 | string                                                      | The session ID this voice state is from                                 |
-| connected_at?              | integer                                                     | The Unix timestamp (in seconds) when the user connected to voice        |
+| connected_at?              | integer                                                     | Unix time (in seconds) of when the user connected to voice              |
 | deaf                       | boolean                                                     | Whether this user is deafened by the guild, if any                      |
 | mute                       | boolean                                                     | Whether this user is muted by the guild, if any                         |
 | self_deaf                  | boolean                                                     | Whether this user is locally deafened                                   |

--- a/pages/resources/voice.mdx
+++ b/pages/resources/voice.mdx
@@ -16,6 +16,7 @@ Used to represent a user's voice connection status.
 | user_id                    | snowflake                                                   | The user ID this voice state is for                                     |
 | member? ^1^                | [guild member](/resources/guild#guild-member-object) object | The guild member this voice state is for                                |
 | session_id                 | string                                                      | The session ID this voice state is from                                 |
+| connected_at?              | integer                                                     | The Unix timestamp (in seconds) when the user connected to voice        |
 | deaf                       | boolean                                                     | Whether this user is deafened by the guild, if any                      |
 | mute                       | boolean                                                     | Whether this user is muted by the guild, if any                         |
 | self_deaf                  | boolean                                                     | Whether this user is locally deafened                                   |
@@ -38,6 +39,7 @@ Used to represent a user's voice connection status.
   "channel_id": "157733188964188161",
   "user_id": "80351110224678912",
   "session_id": "90326bd25d71d39b9ef95b299e3872ff",
+  "connected_at": 1617216331,
   "deaf": false,
   "mute": false,
   "self_deaf": false,


### PR DESCRIPTION
## Summary

identify and document the connected_at field in voice states

---
Task: [task_20260609042127_h8tjnj](http://localhost:8787/?task=task_20260609042127_h8tjnj)
Made with Userdoccers Vibebench.