### PR TITLE
fix(main.tsx): cross page hash navigation now scrolls to the element

### DIFF
--- a/main.tsx
+++ b/main.tsx
@@ -58,6 +58,12 @@ function App() {
     if (document.title !== pageTitle) {
       document.title = pageTitle;
     }
+
+    const hash = location.hash.slice(1);
+
+    if (hash) {
+      document.getElementById(hash)?.scrollIntoView();
+    }
   }, [location.pathname]);
 
   const fadeClasses = classNames("sidebar-fade", {


### PR DESCRIPTION
Previously when navigating from page x to page y where the link to y has a location hash,
the page wouldn't scroll to the appropriate location.

This doesn't "fix" pages maintaining scroll position when navigating from the
nav bar, some might call this a bug I call it a feature, a feature where
it preserves the scroll context of the pages that the user visited so that they
can return to a page and continue where they left off.

Ref (report from Vencord regulars channel):

<img width="807" height="693" alt="image" src="https://github.com/user-attachments/assets/a8f01204-f2b7-4630-aa08-d619d09bc9e1" />