### PR TITLE
Update Linux desktop executable formats for Discord client distribution

### DIFF
--- a/pages/topics/client-distribution.mdx
+++ b/pages/topics/client-distribution.mdx
@@ -79,10 +79,12 @@ Desktop release channels follow [web release channels](#web-release-channel) whe
 
 ###### Desktop Executable Format
 
-| Value  | Description                  |
-| ------ | ---------------------------- |
-| deb    | Debian software package file |
-| tar.gz | Compressed archive file      |
+| Value       | Description                       |
+| ----------- | --------------------------------- |
+| deb         | Debian software package file      |
+| tar.gz      | Compressed archive file           |
+| rpm         | RPM software package file         |
+| pkg.tar.zst | Zstandard-compressed package file |
 
 ### Mobile
 


### PR DESCRIPTION
Updates the client distribution documentation’s Linux desktop executable formats table to include RPM packages and pkg.tar.zst packages alongside the existing deb and tar.gz formats.

Closes #565

---
Task: [task_20260610051334_k0bukv](https://bench.docs.discord.food/?task=task_20260610051334_k0bukv)
Made with Userdoccers Vibebench.