### PR TITLE
chore: add new apex experiments surfaces types

### DIFF
--- a/pages/topics/experiments.mdx
+++ b/pages/topics/experiments.mdx
@@ -619,6 +619,18 @@ Returned experiments are dependent on the requesting [client properties](/refere
 
 </Alert>
 
+<RouteHeader method="GET" url="/apex/seo-experiments/seo_url_slug/{slug}" unauthenticated>
+  Get Apex Experiment Assignments for an invite slug
+</RouteHeader>
+
+Returns an [apex experiments](#apex-experiments) object for the requesting invite slug.
+
+<Alert type="info">
+
+The assignment object uses `seo_url_slug:{slug}` as identifiers for resources instead of snowflakes.
+
+</Alert>
+
 ###### Query String Parameters
 
 | Field   | Type    | Description                                                                                                           |

--- a/pages/topics/experiments.mdx
+++ b/pages/topics/experiments.mdx
@@ -641,11 +641,11 @@ Returned experiments are dependent on the requesting [client properties](/refere
 
 
 
-<RouteHeader method="GET" url="/apex/seo-experiments/seo_url_slug/{slug}" unauthenticated>
-  Get Apex Experiment Assignments for an invite slug
+<RouteHeader method="GET" url="/apex/seo-experiments/seo_url_slug/{key}" unauthenticated>
+  Get Apex Experiment Assignments For Slug
 </RouteHeader>
 
-Returns an [apex experiments](#apex-experiments) object for the requesting invite slug.
+Returns an [apex experiments](#apex-experiments) object for the given slug.
 
 <Alert type="info">
 

--- a/pages/topics/experiments.mdx
+++ b/pages/topics/experiments.mdx
@@ -623,17 +623,20 @@ Returned experiments are dependent on the requesting [client properties](/refere
 
 | Field   | Type    | Description                                                                                                           |
 | ------- | ------- | --------------------------------------------------------------------------------------------------------------------- |
-| surface | integer | The [surface](#apex-experiment-surface) to return apex experiments for (only `APP` and `DEVELOPER_PORTAL` is allowed) |
+| surface | integer | The [surface](#apex-experiment-surface) to return apex experiments for (only `APP` and `DEVELOPER_PORTAL` and `MARKETING` is allowed) |
 
 ###### Apex Experiment Surface
 
-| Value | Name             | Description                                                       |
-| ----- | ---------------- | ----------------------------------------------------------------- |
-| 1     | API              | Return apex experiments that alter API functionality              |
-| 2     | APP              | Return apex experiments that alter client functionality           |
-| 3     | DEVELOPER_PORTAL | Return apex experiments that alter developer portal functionality |
-| 4     | ADMIN_PANEL      | Return apex experiments that alter admin panel functionality      |
-| 5     | ADS_BUDGET_AB    | Return apex experiments that alter ads manager functionality      |
+| Value | Name             | Description                                                         |
+| ----- | ---------------- | --------------------------------------------------------------------|
+| 1     | API              | Return apex experiments that alter API functionality                |
+| 2     | APP              | Return apex experiments that alter client functionality             |
+| 3     | DEVELOPER_PORTAL | Return apex experiments that alter developer portal functionality   |
+| 4     | ADMIN_PANEL      | Return apex experiments that alter admin panel functionality        |
+| 5     | ADS_BUDGET_AB    | Return apex experiments that alter ads manager functionality        |
+| 6     | AV_WORKER        | Return apex experiments that alter av worker functionality          |
+| 7     | SEO              | Return apex experiments that alter seo functionality                |
+| 8     | MARKETING        | Return apex experiments that alter marketing website functionality  |
 
 <RouteHeader method="GET" url="/apex/experiments/metadata" supportsBot>
   Get Metadata for Apex Experiments

--- a/pages/topics/experiments.mdx
+++ b/pages/topics/experiments.mdx
@@ -619,17 +619,6 @@ Returned experiments are dependent on the requesting [client properties](/refere
 
 </Alert>
 
-<RouteHeader method="GET" url="/apex/seo-experiments/seo_url_slug/{slug}" unauthenticated>
-  Get Apex Experiment Assignments for an invite slug
-</RouteHeader>
-
-Returns an [apex experiments](#apex-experiments) object for the requesting invite slug.
-
-<Alert type="info">
-
-The assignment object uses `seo_url_slug:{slug}` as identifiers for resources instead of snowflakes.
-
-</Alert>
 
 ###### Query String Parameters
 
@@ -649,6 +638,20 @@ The assignment object uses `seo_url_slug:{slug}` as identifiers for resources in
 | 6     | AV_WORKER        | Return apex experiments that alter A/V worker functionality          |
 | 7     | SEO              | Return apex experiments that alter SEO page functionality                |
 | 8     | MARKETING        | Return apex experiments that alter marketing website functionality  |
+
+
+
+<RouteHeader method="GET" url="/apex/seo-experiments/seo_url_slug/{slug}" unauthenticated>
+  Get Apex Experiment Assignments for an invite slug
+</RouteHeader>
+
+Returns an [apex experiments](#apex-experiments) object for the requesting invite slug.
+
+<Alert type="info">
+
+The assignment object uses `seo_url_slug:{slug}` as identifiers for resources instead of snowflakes.
+
+</Alert>
 
 <RouteHeader method="GET" url="/apex/experiments/metadata" supportsBot>
   Get Metadata for Apex Experiments

--- a/pages/topics/experiments.mdx
+++ b/pages/topics/experiments.mdx
@@ -623,7 +623,7 @@ Returned experiments are dependent on the requesting [client properties](/refere
 
 | Field   | Type    | Description                                                                                                           |
 | ------- | ------- | --------------------------------------------------------------------------------------------------------------------- |
-| surface | integer | The [surface](#apex-experiment-surface) to return apex experiments for (only `APP` and `DEVELOPER_PORTAL` and `MARKETING` is allowed) |
+| surface | integer | The [surface](#apex-experiment-surface) to return apex experiments for (only `APP` and `DEVELOPER_PORTAL` and `SEO` and `MARKETING` is allowed) |
 
 ###### Apex Experiment Surface
 

--- a/pages/topics/experiments.mdx
+++ b/pages/topics/experiments.mdx
@@ -621,22 +621,22 @@ Returned experiments are dependent on the requesting [client properties](/refere
 
 ###### Query String Parameters
 
-| Field   | Type    | Description                                                                                                           |
-| ------- | ------- | --------------------------------------------------------------------------------------------------------------------- |
+| Field   | Type    | Description                                                                                                                                |
+| ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | surface | integer | The [surface](#apex-experiment-surface) to return apex experiments for (only `APP`, `DEVELOPER_PORTAL`, `SEO`, and `MARKETING` is allowed) |
 
 ###### Apex Experiment Surface
 
-| Value | Name             | Description                                                         |
-| ----- | ---------------- | --------------------------------------------------------------------|
-| 1     | API              | Return apex experiments that alter API functionality                |
-| 2     | APP              | Return apex experiments that alter client functionality             |
-| 3     | DEVELOPER_PORTAL | Return apex experiments that alter developer portal functionality   |
-| 4     | ADMIN_PANEL      | Return apex experiments that alter admin panel functionality        |
-| 5     | ADS_BUDGET_AB    | Return apex experiments that alter ads manager functionality        |
-| 6     | AV_WORKER        | Return apex experiments that alter A/V worker functionality          |
-| 7     | SEO              | Return apex experiments that alter SEO page functionality                |
-| 8     | MARKETING        | Return apex experiments that alter marketing website functionality  |
+| Value | Name             | Description                                                        |
+| ----- | ---------------- | ------------------------------------------------------------------ |
+| 1     | API              | Return apex experiments that alter API functionality               |
+| 2     | APP              | Return apex experiments that alter client functionality            |
+| 3     | DEVELOPER_PORTAL | Return apex experiments that alter developer portal functionality  |
+| 4     | ADMIN_PANEL      | Return apex experiments that alter admin panel functionality       |
+| 5     | ADS_BUDGET_AB    | Return apex experiments that alter ads manager functionality       |
+| 6     | AV_WORKER        | Return apex experiments that alter A/V worker functionality        |
+| 7     | SEO              | Return apex experiments that alter SEO page functionality          |
+| 8     | MARKETING        | Return apex experiments that alter marketing website functionality |
 
 <RouteHeader method="GET" url="/apex/seo-experiments/seo_url_slug/{key}" unauthenticated>
   Get Apex Experiment Assignments For Slug

--- a/pages/topics/experiments.mdx
+++ b/pages/topics/experiments.mdx
@@ -638,8 +638,6 @@ Returned experiments are dependent on the requesting [client properties](/refere
 | 7     | SEO              | Return apex experiments that alter SEO page functionality                |
 | 8     | MARKETING        | Return apex experiments that alter marketing website functionality  |
 
-
-
 <RouteHeader method="GET" url="/apex/seo-experiments/seo_url_slug/{key}" unauthenticated>
   Get Apex Experiment Assignments For Slug
 </RouteHeader>

--- a/pages/topics/experiments.mdx
+++ b/pages/topics/experiments.mdx
@@ -635,7 +635,7 @@ Returned experiments are dependent on the requesting [client properties](/refere
 | 4     | ADMIN_PANEL      | Return apex experiments that alter admin panel functionality        |
 | 5     | ADS_BUDGET_AB    | Return apex experiments that alter ads manager functionality        |
 | 6     | AV_WORKER        | Return apex experiments that alter av worker functionality          |
-| 7     | SEO              | Return apex experiments that alter seo functionality                |
+| 7     | SEO              | Return apex experiments that alter SEO page functionality                |
 | 8     | MARKETING        | Return apex experiments that alter marketing website functionality  |
 
 <RouteHeader method="GET" url="/apex/experiments/metadata" supportsBot>

--- a/pages/topics/experiments.mdx
+++ b/pages/topics/experiments.mdx
@@ -623,7 +623,7 @@ Returned experiments are dependent on the requesting [client properties](/refere
 
 | Field   | Type    | Description                                                                                                           |
 | ------- | ------- | --------------------------------------------------------------------------------------------------------------------- |
-| surface | integer | The [surface](#apex-experiment-surface) to return apex experiments for (only `APP` and `DEVELOPER_PORTAL` and `SEO` and `MARKETING` is allowed) |
+| surface | integer | The [surface](#apex-experiment-surface) to return apex experiments for (only `APP`, `DEVELOPER_PORTAL`, `SEO`, and `MARKETING` is allowed) |
 
 ###### Apex Experiment Surface
 

--- a/pages/topics/experiments.mdx
+++ b/pages/topics/experiments.mdx
@@ -634,7 +634,7 @@ Returned experiments are dependent on the requesting [client properties](/refere
 | 3     | DEVELOPER_PORTAL | Return apex experiments that alter developer portal functionality   |
 | 4     | ADMIN_PANEL      | Return apex experiments that alter admin panel functionality        |
 | 5     | ADS_BUDGET_AB    | Return apex experiments that alter ads manager functionality        |
-| 6     | AV_WORKER        | Return apex experiments that alter av worker functionality          |
+| 6     | AV_WORKER        | Return apex experiments that alter A/V worker functionality          |
 | 7     | SEO              | Return apex experiments that alter SEO page functionality                |
 | 8     | MARKETING        | Return apex experiments that alter marketing website functionality  |
 

--- a/pages/topics/experiments.mdx
+++ b/pages/topics/experiments.mdx
@@ -619,7 +619,6 @@ Returned experiments are dependent on the requesting [client properties](/refere
 
 </Alert>
 
-
 ###### Query String Parameters
 
 | Field   | Type    | Description                                                                                                           |


### PR DESCRIPTION
spotted in protos. new stuff

```diff
// Surfaces
+ AV_WORKER: 6,
+ SEO: 7,
+ MARKETING: 8,
```

Api allows for getting data only for SEO, MARKETING in these newly added surfaces 

https://discord.com/api/v9/apex/experiments?surface=8
https://discord.com/api/v9/apex/experiments?surface=7