### PR TITLE
feat(discovery): update endpoints and docs

### DIFF
--- a/pages/resources/discovery.mdx
+++ b/pages/resources/discovery.mdx
@@ -499,7 +499,7 @@ This endpoint has the following immutable filters set:
 | offset?      | integer | Number of guilds to skip before returning guilds (max 2999)                         |
 | category_id? | integer | The ID of the [discovery category](#discovery-category-object) to filter results by |
 
-<RouteHeader method="GET" url="/discovery/search" unauthenticated>
+<RouteHeader method="GET" url="/index/servers/search" unauthenticated>
   Search Published Guilds
 </RouteHeader>
 
@@ -524,7 +524,7 @@ This endpoint has the following immutable filters set:
 | limit?  | integer | The maximum number of guilds to return (1-48, default 48)   |
 | offset? | integer | Number of guilds to skip before returning guilds (max 2999) |
 
-<RouteHeader method="GET" url="/discovery/{guild.id}" unauthenticated>
+<RouteHeader method="GET" url="/index/servers/{guild.id}" unauthenticated>
   Get Discovery Slug
 </RouteHeader>
 

--- a/pages/resources/discovery.mdx
+++ b/pages/resources/discovery.mdx
@@ -41,9 +41,9 @@ A partial guild object returned from discovery, [Get Emoji Guild](/resources/emo
 | Field                      | Type                                                                      | Description                                                                                      |
 | -------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
 | content_type               | string                                                                    | Content type (often "servers")                                                                   |
-| parent_id                  | string                                                                    | The guild's id                                                                                   |
+| parent_id                  | snowflake                                                                 | The guild's id                                                                                   |
 | seo                        | array[string]                                                             | The guild's [metadata](#discoverable-guild-metadata-structure)                                   |
-| data                       | array[string]                                                             | The guild's [page data](#discoverable-guild-page-data-structure)                                 |
+| data                       | array[string]                                                             | The guild's [page information/data](#discoverable-guild-page-information-structure)              |
 
 ###### Discoverable Guild Metadata Structure
 
@@ -53,14 +53,23 @@ A partial guild object returned from discovery, [Get Emoji Guild](/resources/emo
 | description                | string                                                                    | The description for the guild                                                                    |
 | og_image_url               | string                                                                    | The guild's banner URL                                                                           |
 | og_image_alt               | string                                                                    | The guild's image alt                                                                            |
-| json_ld                    | array[string]                                                             | something something                                                                              |
+| json_ld                    | array[string]                                                             | Guild metadata shown in json_ld format                                                           |
 
-###### Discoverable Guild Page Data Structure
+###### Discoverable Guild Page Information Structure
 
 | Field                      | Type                                                                      | Description                                                                                      |
 | -------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
 | page_type                  | string                                                                    | Page type for the guild (often "discovery")                                                      |
 | guild                      | array[string]                                                             | The actual data for this guild                                                                   |
+| announcment_channels       | array[string]                                                             | The guild's announcment channels (#discoverable-guild-announcment-channel-object-structure)      |
+
+###### Discoverable Guild Announcment Channel Object Structure
+
+| Field                      | Type                                                                      | Description                                                                                      |
+| -------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| id                         | snowflake                                                                 | The ID of the channel                                                                            |
+| name                       | string                                                                    | The name of the channel                                                                          |
+| topic                      | string                                                                    | The topic of the channel                                                                         |
 
 ###### Discoverable Guild Data Structure
 
@@ -104,23 +113,24 @@ A partial guild object returned from discovery, [Get Emoji Guild](/resources/emo
 
 ###### Example Discoverable Guild Metadata Object
 ```json
+{
   "seo": {
-    "title": "Elite Tokens - Discord Servers",
-    "description": "The largest gaming matchmaking platform designed for you to compete in matches, tournaments, and more!",
-    "canonical_url": "https://discord.com/servers/elite-tokens-752630786561409076",
-    "og_image_url": "https://cdn.discordapp.com/discovery-splashes/752630786561409076/7757f702508d00498630eb8922d59de4.jpg?size=512&format=auto",
+    "title": "Discord Town Hall - Discord Servers",
+    "description": "Welcome to Discord Town Hall—a community run by Discord, for Discord users! Join for the latest product news & events.",
+    "canonical_url": "https://discord.com/servers/discord-town-hall-169256939211980800",
+    "og_image_url": "https://cdn.discordapp.com/discovery-splashes/169256939211980800/cfd35a3e0068c97c61828ee9fd6bf69d.jpg?size=512&format=auto",
     "og_image_alt": null,
     "json_ld": {
       "@context": "https://schema.org",
       "@graph": [
         {
           "@type": "ProfilePage",
-          "name": "Elite Tokens",
-          "url": "https://discord.com/servers/elite-tokens-752630786561409076",
+          "name": "Discord Town Hall",
+          "url": "https://discord.com/servers/discord-town-hall-169256939211980800",
           "mainEntity": {
             "@type": "Organization",
-            "name": "Elite Tokens",
-            "identifier": "752630786561409076",
+            "name": "Discord Town Hall",
+            "identifier": "169256939211980800",
             "memberOf": {
               "@type": "WebSite",
               "name": "Discord",
@@ -129,11 +139,11 @@ A partial guild object returned from discovery, [Get Emoji Guild](/resources/emo
             "interactionStatistic": {
               "@type": "InteractionCounter",
               "interactionType": "https://schema.org/SubscribeAction",
-              "userInteractionCount": 226362
+              "userInteractionCount": 485042
             },
-            "image": "https://cdn.discordapp.com/discovery-splashes/752630786561409076/7757f702508d00498630eb8922d59de4.jpg?size=512&format=auto"
+            "image": "https://cdn.discordapp.com/discovery-splashes/169256939211980800/cfd35a3e0068c97c61828ee9fd6bf69d.jpg?size=512&format=auto"
           },
-          "description": "The largest gaming matchmaking platform designed for you to compete in matches, tournaments, and more!"
+          "description": "Welcome to Discord Town Hall—a community run by Discord, for Discord users! Join for the latest product news & events."
         },
         {
           "@type": "BreadcrumbList",
@@ -153,131 +163,148 @@ A partial guild object returned from discovery, [Get Emoji Guild](/resources/emo
             {
               "@type": "ListItem",
               "position": 3,
-              "name": "Elite Tokens",
-              "item": "https://discord.com/servers/elite-tokens-752630786561409076"
+              "name": "Discord Town Hall",
+              "item": "https://discord.com/servers/discord-town-hall-169256939211980800"
             }
           ]
         }
       ]
     }
+  }
+}
 ```
 
 ###### Example Discoverable Guild Data Object
 
 ```json
+{
   "data": {
     "page_type": "discovery",
     "guild": {
-      "id": "752630786561409076",
-      "name": "Elite Tokens",
-      "description": "The largest gaming matchmaking platform designed for you to compete in matches, tournaments, and more!",
-      "icon": "279638b68c37d22b7d4d5cda32fa3ecf",
-      "splash": "948e0a5d28677d2f42374258a0f23834",
-      "banner": "ef1cc2e7260951fdc1005d90f3557b94",
-      "approximate_presence_count": 38542,
-      "approximate_member_count": 226362,
-      "premium_subscription_count": 24,
+      "id": "169256939211980800",
+      "name": "Discord Town Hall",
+      "description": "Welcome to Discord Town Hall—a community run by Discord, for Discord users! Join for the latest product news & events.",
+      "icon": "b975d0a4c365f143c42b302fbe525fef",
+      "splash": "02bb736628410e725666aa6fd036d217",
+      "banner": "f1990a1b6d39cecda1805d28739524d5",
+      "approximate_presence_count": 97909,
+      "approximate_member_count": 485042,
+      "premium_subscription_count": 158,
       "preferred_locale": "en-US",
       "auto_removed": false,
-      "discovery_splash": "7757f702508d00498630eb8922d59de4",
-      "primary_category_id": 1,
-      "vanity_url_code": "elitetokens",
+      "discovery_splash": "cfd35a3e0068c97c61828ee9fd6bf69d",
+      "primary_category_id": 14,
+      "vanity_url_code": "discord-townhall",
       "is_published": true,
       "keywords": [
-        "1v1",
-        "2v2",
-        "Boxfights",
-        "Elite",
-        "Fortnite",
-        "Fortnite Tokens",
-        "LFG",
-        "Realistics",
-        "Tokens",
-        "Zonewars"
+        "Discord",
+        "Town Hall"
       ],
       "nsfw_properties": null,
       "features": [
-        "AGE_VERIFICATION_LARGE_GUILD",
         "ANIMATED_BANNER",
         "ANIMATED_ICON",
         "AUDIO_BITRATE_128_KBPS",
         "AUDIO_BITRATE_256_KBPS",
         "AUDIO_BITRATE_384_KBPS",
+        "AUTOMOD_TRIGGER_KEYWORD_FILTER",
+        "AUTOMOD_TRIGGER_SPAM_LINK_FILTER",
         "AUTOMOD_TRIGGER_USER_PROFILE",
         "AUTO_MODERATION",
         "BANNER",
-        "BYPASS_SLOWMODE_PERMISSION_MIGRATION_COMPLETE",
         "CHANNEL_ICON_EMOJIS_GENERATED",
         "COMMUNITY",
         "COMMUNITY_EXP_LARGE_GATED",
         "CONSIDERED_EXTERNALLY_DISCOVERABLE",
-        "CONVERSATIONS_EXTRACTION_CONTROL",
+        "CONTENT_INDEXING",
         "DISCOVERABLE",
         "ENABLED_DISCOVERABLE_BEFORE",
         "ENHANCED_ROLE_COLORS",
+        "FEATURABLE",
+        "GUILD_COMMUNICATION_DISABLED_GUILDS",
+        "GUILD_HOME_OVERRIDE",
         "GUILD_ONBOARDING",
+        "GUILD_ONBOARDING_ADMIN_ONLY",
         "GUILD_ONBOARDING_EVER_ENABLED",
         "GUILD_ONBOARDING_HAS_PROMPTS",
-        "GUILD_SERVER_GUIDE",
         "GUILD_TAGS",
+        "GUILD_TAGS_BADGE_PACK_FLEX",
         "GUILD_WEB_PAGE_VANITY_URL",
+        "HAS_DIRECTORY_ENTRY",
+        "INCREASED_THREAD_LIMIT",
         "INVITE_SPLASH",
         "MAX_FILE_SIZE_100_MB",
         "MAX_FILE_SIZE_50_MB",
+        "MEMBER_SAFETY_PAGE_ROLLOUT",
         "MEMBER_VERIFICATION_GATE_ENABLED",
         "NEWS",
         "NEW_THREAD_PERMISSIONS",
+        "PARTNERED",
         "PREVIEW_ENABLED",
         "ROLE_ICONS",
         "SOUNDBOARD",
         "STAGE_CHANNEL_VIEWERS_150",
         "STAGE_CHANNEL_VIEWERS_300",
         "STAGE_CHANNEL_VIEWERS_50",
-        "TEXT_IN_VOICE_ENABLED",
+        "TEXT_IN_STAGE_ENABLED",
         "THREADS_ENABLED",
         "TIERLESS_BOOSTING",
+        "TIERLESS_BOOSTING_SYSTEM_MESSAGE",
         "VANITY_URL",
+        "VERIFIED",
         "VIDEO_BITRATE_ENHANCED",
         "VIDEO_QUALITY_1080_60FPS",
-        "VIDEO_QUALITY_720_60FPS"
+        "VIDEO_QUALITY_720_60FPS",
+        "VIP_REGIONS",
+        "WELCOME_SCREEN_ENABLED"
       ],
-      "created_at": "2020-09-07T20:46:02.720000+00:00",
+      "created_at": "2016-04-12T01:26:38.950000+00:00",
       "reasons_to_join": [
         {
-          "reason": "Play a variety of 1v1-4v4 modes",
+          "reason": "Get up-to-date information on the latest Discord features & updates right from Discord staff!",
+          "emoji_id": null,
+          "emoji_name": "💡"
+        },
+        {
+          "reason": "Attend Q&As, Stage Events, and workshops hosted by Discord Staff and other prominent community members.",
+          "emoji_id": null,
+          "emoji_name": "🔖"
+        },
+        {
+          "reason": "Attend game nights & Activities events.",
+          "emoji_id": null,
+          "emoji_name": "🚀"
+        },
+        {
+          "reason": "Meet & hang out with other Discord fans!",
           "emoji_id": null,
           "emoji_name": "👥"
-        },
-        {
-          "reason": "Participate in tournaments",
-          "emoji_id": null,
-          "emoji_name": "🏆"
-        },
-        {
-          "reason": "Enter server-based events",
-          "emoji_id": null,
-          "emoji_name": "❤️"
-        },
-        {
-          "reason": "Active community",
-          "emoji_id": null,
-          "emoji_name": "💬"
         }
       ],
       "social_links": [
-        "https://twitter.com/EliteTokensGG"
+        "https://instagram.com/discord",
+        "https://tiktok.com/discord",
+        "https://twitter.com/discord",
+        "https://youtube.com/discord"
       ],
-      "about": "Elite Tokens is a matchmaking platform designed for players to compete against each other in matches and tournaments!\n\nPlay a variety of game modes including Boxfights, Realistics, Zonewars, and more!\n\nYou can also find dedicated channels to look for players, post clips, and share any suggestions or feedback. \n\nFind out more information at https://elitetokens.gg/",
+      "about": "Discord Town Hall is the official server for anyone who loves Discord! Here you can stay in-the-know about the latest happenings at Discord - from product updates, special events, and community updates.\n\nTown Hall is a great place to meet & connect with other fans of Discord and hear from Discord Staff. If you enjoy Discord and everything we have to offer for our wonderful fans - join the conversation in Town Hall!",
       "category_ids": [
-        15,
-        30,
+        39,
+        3,
+        33,
         1,
-        14,
-        46
+        49
       ]
     },
-    "announcement_channels": []
+    "announcement_channels": [
+      {
+        "id": "889960284020699156",
+        "name": "🏠-discord-updates",
+        "topic": "Follow this channel to stay informed on what's happening at Discord!"
+      }
+    ]
   }
+}
 ```
 
 ### Discovery Requirements Object

--- a/pages/resources/discovery.mdx
+++ b/pages/resources/discovery.mdx
@@ -41,9 +41,9 @@ A partial guild object returned from discovery, [Get Emoji Guild](/resources/emo
 | Field                      | Type                                                                      | Description                                                                                      |
 | -------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
 | content_type               | string                                                                    | Content type (often "servers")                                                                   |
-| parent_id                  | snowflake                                                                 | The guild's id                                                                                   |
+| parent_id                  | snowflake                                                                 | The ID of the guild                                                                              |
 | seo                        | array[string]                                                             | The guild's [metadata](#discoverable-guild-metadata-structure)                                   |
-| data                       | array[string]                                                             | The guild's [page information/data](#discoverable-guild-page-information-structure)              |
+| data                       | array[string]                                                             | The guild's [page information](#discoverable-guild-page-information-structure)                   |
 
 ###### Discoverable Guild Metadata Structure
 
@@ -53,7 +53,7 @@ A partial guild object returned from discovery, [Get Emoji Guild](/resources/emo
 | description                | string                                                                    | The description for the guild                                                                    |
 | og_image_url               | string                                                                    | The guild's banner URL                                                                           |
 | og_image_alt               | string                                                                    | The guild's image alt                                                                            |
-| json_ld                    | array[string]                                                             | Guild metadata shown in json_ld format                                                           |
+| json_ld                    | array[string]                                                             | Guild metadata shown in json_ld format (shown in example)                                        |
 
 ###### Discoverable Guild Page Information Structure
 
@@ -61,9 +61,9 @@ A partial guild object returned from discovery, [Get Emoji Guild](/resources/emo
 | -------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
 | page_type                  | string                                                                    | Page type for the guild (often "discovery")                                                      |
 | guild                      | array[string]                                                             | The actual data for this guild                                                                   |
-| announcment_channels       | array[string]                                                             | The guild's announcment channels (#discoverable-guild-announcment-channel-object-structure)      |
+| announcement_channels      | array[string]                                                             | The guild's announcement channels (#discoverable-guild-announcement-channel-object-structure)    |
 
-###### Discoverable Guild Announcment Channel Object Structure
+###### Discoverable Guild Announcement Channel Object Structure
 
 | Field                      | Type                                                                      | Description                                                                                      |
 | -------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |

--- a/pages/resources/discovery.mdx
+++ b/pages/resources/discovery.mdx
@@ -41,9 +41,9 @@ A partial guild object returned from discovery, [Get Emoji Guild](/resources/emo
 | Field                      | Type                                                                      | Description                                                                                      |
 | -------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
 | content_type               | string                                                                    | Content type (often "servers")                                                                   |
-| parent_id                  | string                                                                    | The name of the guild (2-100 characters)                                                         |
+| parent_id                  | string                                                                    | The guild's id                                                                                   |
 | seo                        | array[string]                                                             | The guild's [metadata](#discoverable-guild-metadata-structure)                                   |
-| data                       | array[string]                                                             | The guild's [actual data](#discoverable-guild-data-structure)                                    |
+| data                       | array[string]                                                             | The guild's [page data](#discoverable-guild-page-data-structure)                                 |
 
 ###### Discoverable Guild Metadata Structure
 

--- a/pages/resources/discovery.mdx
+++ b/pages/resources/discovery.mdx
@@ -42,7 +42,7 @@ A partial guild object returned from discovery, [Get Emoji Guild](/resources/emo
 | -------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
 | content_type               | string                                                                    | Content type (often "servers")                                                                   |
 | parent_id                  | string                                                                    | The name of the guild (2-100 characters)                                                         |
-| seo                        | array[string]                                                             | The guild's [metadata](#discoverable-guild-metdata-structure)                                    |
+| seo                        | array[string]                                                             | The guild's [metadata](#discoverable-guild-metadata-structure)                                   |
 | data                       | array[string]                                                             | The guild's [actual data](#discoverable-guild-data-structure)                                    |
 
 ###### Discoverable Guild Metadata Structure

--- a/pages/resources/discovery.mdx
+++ b/pages/resources/discovery.mdx
@@ -42,8 +42,8 @@ A partial guild object returned from discovery, [Get Emoji Guild](/resources/emo
 | -------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
 | content_type               | string                                                                    | Content type (often "servers")                                                                   |
 | parent_id                  | string                                                                    | The name of the guild (2-100 characters)                                                         |
-| seo                        | array[string]                                                             | The guild's [metadata](/reference#discoverable-guild-metdata-structure)                          |
-| data                       | array[string]                                                             | The guild's [actual data](/reference#discoverable-guild-data-structure)                          |
+| seo                        | array[string]                                                             | The guild's [metadata](#discoverable-guild-metdata-structure)                                    |
+| data                       | array[string]                                                             | The guild's [actual data](#discoverable-guild-data-structure)                                    |
 
 ###### Discoverable Guild Metadata Structure
 

--- a/pages/resources/discovery.mdx
+++ b/pages/resources/discovery.mdx
@@ -40,6 +40,32 @@ A partial guild object returned from discovery, [Get Emoji Guild](/resources/emo
 
 | Field                      | Type                                                                      | Description                                                                                      |
 | -------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| content_type               | string                                                                    | Content type (often "servers")                                                                   |
+| parent_id                  | string                                                                    | The name of the guild (2-100 characters)                                                         |
+| seo                        | array[string]                                                             | The guild's [metadata](/reference#discoverable-guild-metdata-structure)                          |
+| data                       | array[string]                                                             | The guild's [actual data](/reference#discoverable-guild-data-structure)                          |
+
+###### Discoverable Guild Metadata Structure
+
+| Field                      | Type                                                                      | Description                                                                                      |
+| -------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| title                      | string                                                                    | The name of the guild                                                                            |
+| description                | string                                                                    | The description for the guild                                                                    |
+| og_image_url               | string                                                                    | The guild's banner URL                                                                           |
+| og_image_alt               | string                                                                    | The guild's image alt                                                                            |
+| json_ld                    | array[string]                                                             | something something                                                                              |
+
+###### Discoverable Guild Page Data Structure
+
+| Field                      | Type                                                                      | Description                                                                                      |
+| -------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| page_type                  | string                                                                    | Page type for the guild (often "discovery")                                                      |
+| guild                      | array[string]                                                             | The actual data for this guild                                                                   |
+
+###### Discoverable Guild Data Structure
+
+| Field                      | Type                                                                      | Description                                                                                      |
+| -------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
 | id                         | snowflake                                                                 | The ID of the guild                                                                              |
 | name                       | string                                                                    | The name of the guild (2-100 characters)                                                         |
 | icon                       | ?string                                                                   | The guild's [icon hash](/reference#cdn-formatting)                                               |
@@ -76,58 +102,182 @@ A partial guild object returned from discovery, [Get Emoji Guild](/resources/emo
 
 ^3^ Only included when [searching discovery](#searching-discovery).
 
-###### Example Discoverable Guild
+###### Example Discoverable Guild Metadata Object
+```json
+  "seo": {
+    "title": "Elite Tokens - Discord Servers",
+    "description": "The largest gaming matchmaking platform designed for you to compete in matches, tournaments, and more!",
+    "canonical_url": "https://discord.com/servers/elite-tokens-752630786561409076",
+    "og_image_url": "https://cdn.discordapp.com/discovery-splashes/752630786561409076/7757f702508d00498630eb8922d59de4.jpg?size=512&format=auto",
+    "og_image_alt": null,
+    "json_ld": {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "ProfilePage",
+          "name": "Elite Tokens",
+          "url": "https://discord.com/servers/elite-tokens-752630786561409076",
+          "mainEntity": {
+            "@type": "Organization",
+            "name": "Elite Tokens",
+            "identifier": "752630786561409076",
+            "memberOf": {
+              "@type": "WebSite",
+              "name": "Discord",
+              "url": "https://discord.com"
+            },
+            "interactionStatistic": {
+              "@type": "InteractionCounter",
+              "interactionType": "https://schema.org/SubscribeAction",
+              "userInteractionCount": 226362
+            },
+            "image": "https://cdn.discordapp.com/discovery-splashes/752630786561409076/7757f702508d00498630eb8922d59de4.jpg?size=512&format=auto"
+          },
+          "description": "The largest gaming matchmaking platform designed for you to compete in matches, tournaments, and more!"
+        },
+        {
+          "@type": "BreadcrumbList",
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "Discord",
+              "item": "https://discord.com"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "Servers",
+              "item": "https://discord.com/servers"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "Elite Tokens",
+              "item": "https://discord.com/servers/elite-tokens-752630786561409076"
+            }
+          ]
+        }
+      ]
+    }
+```
+
+###### Example Discoverable Guild Data Object
 
 ```json
-{
-  "id": "752630786561409076",
-  "name": "Elite Creative",
-  "description": "The largest Fortnite Creative server across the globe. Join a Creative community offering events, 1v1s. and more!",
-  "icon": "278da1c7740e394657c1179f4782aef1",
-  "splash": "2b4ae5cdd71038b4880b1b57a6e5dacb",
-  "banner": "57e939e67aebaf232d28205603020b55",
-  "approximate_presence_count": 21125,
-  "approximate_member_count": 155455,
-  "premium_subscription_count": 17,
-  "preferred_locale": "en-US",
-  "auto_removed": false,
-  "discovery_splash": "9d7ec672b89b320ef7a51e5b6ae453b8",
-  "primary_category_id": 1,
-  "vanity_url_code": "creative",
-  "is_published": true,
-  "keywords": [
-    "Fortnite",
-    "Creative",
-    "Fortnite Creative",
-    "Boxfights",
-    "Zonewars",
-    "Buildfights",
-    "1v1",
-    "EU",
-    "NA",
-    "Creator"
-  ],
-  "features": [
-    "ANIMATED_BANNER",
-    "ANIMATED_ICON",
-    "AUTO_MODERATION",
-    "BANNER",
-    "COMMUNITY",
-    "DISCOVERABLE",
-    "ENABLED_DISCOVERABLE_BEFORE",
-    "GUILD_ONBOARDING_EVER_ENABLED",
-    "GUILD_WEB_PAGE_VANITY_URL",
-    "INVITE_SPLASH",
-    "NEWS",
-    "PREVIEW_ENABLED",
-    "RAID_ALERTS_ENABLED",
-    "ROLE_ICONS",
-    "VANITY_URL",
-    "WELCOME_SCREEN_ENABLED"
-  ],
-  "emojis": [],
-  "emoji_count": 339
-}
+  "data": {
+    "page_type": "discovery",
+    "guild": {
+      "id": "752630786561409076",
+      "name": "Elite Tokens",
+      "description": "The largest gaming matchmaking platform designed for you to compete in matches, tournaments, and more!",
+      "icon": "279638b68c37d22b7d4d5cda32fa3ecf",
+      "splash": "948e0a5d28677d2f42374258a0f23834",
+      "banner": "ef1cc2e7260951fdc1005d90f3557b94",
+      "approximate_presence_count": 38542,
+      "approximate_member_count": 226362,
+      "premium_subscription_count": 24,
+      "preferred_locale": "en-US",
+      "auto_removed": false,
+      "discovery_splash": "7757f702508d00498630eb8922d59de4",
+      "primary_category_id": 1,
+      "vanity_url_code": "elitetokens",
+      "is_published": true,
+      "keywords": [
+        "1v1",
+        "2v2",
+        "Boxfights",
+        "Elite",
+        "Fortnite",
+        "Fortnite Tokens",
+        "LFG",
+        "Realistics",
+        "Tokens",
+        "Zonewars"
+      ],
+      "nsfw_properties": null,
+      "features": [
+        "AGE_VERIFICATION_LARGE_GUILD",
+        "ANIMATED_BANNER",
+        "ANIMATED_ICON",
+        "AUDIO_BITRATE_128_KBPS",
+        "AUDIO_BITRATE_256_KBPS",
+        "AUDIO_BITRATE_384_KBPS",
+        "AUTOMOD_TRIGGER_USER_PROFILE",
+        "AUTO_MODERATION",
+        "BANNER",
+        "BYPASS_SLOWMODE_PERMISSION_MIGRATION_COMPLETE",
+        "CHANNEL_ICON_EMOJIS_GENERATED",
+        "COMMUNITY",
+        "COMMUNITY_EXP_LARGE_GATED",
+        "CONSIDERED_EXTERNALLY_DISCOVERABLE",
+        "CONVERSATIONS_EXTRACTION_CONTROL",
+        "DISCOVERABLE",
+        "ENABLED_DISCOVERABLE_BEFORE",
+        "ENHANCED_ROLE_COLORS",
+        "GUILD_ONBOARDING",
+        "GUILD_ONBOARDING_EVER_ENABLED",
+        "GUILD_ONBOARDING_HAS_PROMPTS",
+        "GUILD_SERVER_GUIDE",
+        "GUILD_TAGS",
+        "GUILD_WEB_PAGE_VANITY_URL",
+        "INVITE_SPLASH",
+        "MAX_FILE_SIZE_100_MB",
+        "MAX_FILE_SIZE_50_MB",
+        "MEMBER_VERIFICATION_GATE_ENABLED",
+        "NEWS",
+        "NEW_THREAD_PERMISSIONS",
+        "PREVIEW_ENABLED",
+        "ROLE_ICONS",
+        "SOUNDBOARD",
+        "STAGE_CHANNEL_VIEWERS_150",
+        "STAGE_CHANNEL_VIEWERS_300",
+        "STAGE_CHANNEL_VIEWERS_50",
+        "TEXT_IN_VOICE_ENABLED",
+        "THREADS_ENABLED",
+        "TIERLESS_BOOSTING",
+        "VANITY_URL",
+        "VIDEO_BITRATE_ENHANCED",
+        "VIDEO_QUALITY_1080_60FPS",
+        "VIDEO_QUALITY_720_60FPS"
+      ],
+      "created_at": "2020-09-07T20:46:02.720000+00:00",
+      "reasons_to_join": [
+        {
+          "reason": "Play a variety of 1v1-4v4 modes",
+          "emoji_id": null,
+          "emoji_name": "👥"
+        },
+        {
+          "reason": "Participate in tournaments",
+          "emoji_id": null,
+          "emoji_name": "🏆"
+        },
+        {
+          "reason": "Enter server-based events",
+          "emoji_id": null,
+          "emoji_name": "❤️"
+        },
+        {
+          "reason": "Active community",
+          "emoji_id": null,
+          "emoji_name": "💬"
+        }
+      ],
+      "social_links": [
+        "https://twitter.com/EliteTokensGG"
+      ],
+      "about": "Elite Tokens is a matchmaking platform designed for players to compete against each other in matches and tournaments!\n\nPlay a variety of game modes including Boxfights, Realistics, Zonewars, and more!\n\nYou can also find dedicated channels to look for players, post clips, and share any suggestions or feedback. \n\nFind out more information at https://elitetokens.gg/",
+      "category_ids": [
+        15,
+        30,
+        1,
+        14,
+        46
+      ]
+    },
+    "announcement_channels": []
+  }
 ```
 
 ### Discovery Requirements Object


### PR DESCRIPTION
updates the nonexistent `/discovery/search` endpoint with `/index/servers/search` and `/discovery/${guild.id}` with `/index/servers/{guild.id}`, aswell as updating the data from these endpoints (this also replaces the example's server with another server that has a bit more data)