### PR TITLE
docs(scheduled-messages): document message scheduling

### DIFF
--- a/lib/endpoints.ts
+++ b/lib/endpoints.ts
@@ -61,6 +61,7 @@ export const ENDPOINT_VARS: Record<string, string | null> = {
   referral: "/resources/premium-referral#premium-referral-object",
   role: "/resources/guild#role-object",
   sdk_release: "/resources/application#social-sdk-release-object",
+  scheduled_message: "/resources/scheduled-messages#scheduled-message-object",
   sku: "/resources/store#sku-object",
   sound: "/resources/soundboard#soundboard-sound-object",
   stage_instance: "/resources/stage-instance#stage-instance-object",

--- a/pages/resources/scheduled-messages.mdx
+++ b/pages/resources/scheduled-messages.mdx
@@ -1,0 +1,83 @@
+# Scheduled Messages
+
+Scheduled messages are messages queued to be sent at a future timestamp.
+
+### Scheduled Message Object
+
+Represents a message queued to be sent later.
+
+###### Scheduled Message Structure
+
+| Field                | Type                                                                                | Description                                  |
+| -------------------- | ----------------------------------------------------------------------------------- | -------------------------------------------- |
+| user_id              | snowflake                                                                           | The ID of the user who scheduled the message |
+| scheduled_message_id | snowflake                                                                           | The ID of the scheduled message              |
+| send_at_timestamp    | ISO8601 timestamp                                                                   | When the message will be sent                |
+| scheduled_message    | [scheduled message data](#scheduled-message-data-structure) object                  | The message data to send                     |
+| state                | integer                                                                             | The current state of the scheduled message   |
+| attachment_uploads?  | array[[scheduled attachment upload](#scheduled-attachment-upload-structure) object] | Uploaded attachments for the message         |
+
+###### Scheduled Message Data Structure
+
+| Field             | Type                                                                     | Description                                            |
+| ----------------- | ------------------------------------------------------------------------ | ------------------------------------------------------ |
+| channel_id        | snowflake                                                                | The ID of the destination channel                      |
+| content           | string                                                                   | The message content                                    |
+| type              | integer                                                                  | The [type](/resources/message#message-type) of message |
+| flags             | integer                                                                  | The [message flags](/resources/message#message-flags)  |
+| message_reference | ?[message reference](/resources/message#message-reference-object) object | The message reference                                  |
+
+###### Scheduled Attachment Upload Structure
+
+| Field             | Type    | Description                      |
+| ----------------- | ------- | -------------------------------- |
+| filename          | string  | The original filename            |
+| uploaded_filename | string  | The uploaded attachment filename |
+| description?      | ?string | The attachment description       |
+| title?            | ?string | The attachment title             |
+
+## Endpoints
+
+<RouteHeader method="POST" url="/users/@me/scheduled-messages">
+  Create Scheduled Message
+</RouteHeader>
+
+Creates a scheduled message. Returns a [scheduled message](#scheduled-message-object) object on success.
+
+###### JSON Params
+
+| Field               | Type                                                                     | Description                                           |
+| ------------------- | ------------------------------------------------------------------------ | ----------------------------------------------------- |
+| channel_id          | snowflake                                                                | The ID of the channel                                 |
+| content             | string                                                                   | The content                                           |
+| scheduled_timestamp | ISO8601 timestamp                                                        | When the message will be sent                         |
+| flags               | integer                                                                  | The [message flags](/resources/message#message-flags) |
+| message_reference   | [message reference](/resources/message#message-reference-object) object  | The message reference                                 |
+| allowed_mentions    | [allowed mentions](/resources/message#allowed-mentions-object) object    | The allowed mentions                                  |
+| attachments?        | array[partial [attachment](/resources/message#attachment-object) object] | The attachments                                       |
+
+<RouteHeader method="GET" url="/users/@me/scheduled-messages">
+  List Scheduled Messages
+</RouteHeader>
+
+Returns a list of [scheduled message](#scheduled-message-object) objects.
+
+<RouteHeader method="PATCH" url="/users/@me/scheduled-messages/{scheduled_message.id}">
+  Modify Scheduled Message
+</RouteHeader>
+
+Modifies a scheduled message. Returns the updated [scheduled message](#scheduled-message-object) object on success.
+
+###### JSON Params
+
+| Field                | Type              | Description                                           |
+| -------------------- | ----------------- | ----------------------------------------------------- |
+| scheduled_timestamp? | ISO8601 timestamp | When the message will be sent                         |
+| content?             | string            | The message content                                   |
+| flags?               | integer           | The [message flags](/resources/message#message-flags) |
+
+<RouteHeader method="DELETE" url="/users/@me/scheduled-messages/{scheduled_message.id}">
+  Delete Scheduled Message
+</RouteHeader>
+
+Cancels and deletes a scheduled message. Returns a 204 empty response on success.


### PR DESCRIPTION
> This is an attempt to document the missing endpoints faster, this is by the help of ai and manual review.

## Summary

Generated using opencode (gpt 5.6 sol). An agent periodically checks for new review comments and will address feedback when detected. Responses may not be immediate.

- document scheduled message, nested message data, and attachment upload structures
- document creating, listing, modifying, and deleting scheduled messages
- include source-backed timestamp, optionality, reference, mention, and attachment types

## Testing

- `pnpm exec prettier --check pages/resources/scheduled-messages.mdx lib/endpoints.ts`
- `pnpm run test:links`
- `pnpm run build`