### PR TITLE
Correct provisional account endpoints auth types

### DIFF
--- a/pages/topics/oauth2.mdx
+++ b/pages/topics/oauth2.mdx
@@ -899,7 +899,7 @@ To change the display name of a provisional account, use the [Modify Current Use
 | APPLE_ID_TOKEN                    | ID token for Apple ID                                                                               |
 | PLAYSTATION_NETWORK_ID_TOKEN      | ID token for PlayStation Network                                                                    |
 
-<RouteHeader method="POST" url="/partner-sdk/child-token">
+<RouteHeader method="POST" url="/partner-sdk/child-token" unauthenticated>
   Exchange Provisional Account Child Token
 </RouteHeader>
 
@@ -912,7 +912,7 @@ Exchanges a parent application token for a child application token. Returns an [
 | child_application_id | snowflake | The ID of the child application                     |
 | parent_access_token  | string    | The parent application token (max 10240 characters) |
 
-<RouteHeader method="POST" url="/partner-sdk/token/bot">
+<RouteHeader method="POST" url="/partner-sdk/token/bot" supportsBot>
   Get Provisional Account Token with Bot
 </RouteHeader>
 
@@ -975,7 +975,7 @@ Unmerging invalidates all access and refresh tokens for the user. Users can also
 
 ^1^ Not required if the application has the [`PUBLIC_OAUTH2_CLIENT` application flag](/resources/application#application-flags).
 
-<RouteHeader method="POST" url="/partner-sdk/provisional-accounts/unmerge/bot">
+<RouteHeader method="POST" url="/partner-sdk/provisional-accounts/unmerge/bot" supportsBot>
   Unmerge Provisional Account with Bot
 </RouteHeader>
 


### PR DESCRIPTION
- [Get Provisional Account Token with Bot](https://docs.discord.food/topics/oauth2#get-provisional-account-token-with-bot) and [Unmerge Provisional Account with Bot](https://docs.discord.food/topics/oauth2#unmerge-provisional-account-with-bot) require a [bot token](https://docs.discord.com/developers/discord-social-sdk/development-guides/provisional-accounts/bot-token-endpoint#server-create-the-provisional-token)
- [Exchange Provisional Account Child Token](https://docs.discord.food/topics/oauth2#exchange-provisional-account-child-token) is [unauthenticated](https://docs.discord.com/developers/discord-social-sdk/development-guides/publisher-level-account-linking#exchange-for-child-token)